### PR TITLE
Frontend/setup-fetch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,12 @@ uvicorn app.main:app --reload
   - `/src/app` - App Router pages
   - `/src/components` - Reusable components
   - `/src/feature` - Feature-specific components
+  - `/src/api` - API integration layer
+    - `/client` - HTTP client with Clerk auth
+    - `/constants` - API endpoints & configuration
+    - `/endpoints` - 1:1 API endpoint functions
+    - `/server-actions` - Next.js server actions for SSR
+    - `/types` - TypeScript interfaces matching backend schemas
 - `/backend` - FastAPI application
   - `/app/api` - API endpoints
   - `/app/database` - Database models and repositories
@@ -43,6 +49,23 @@ uvicorn app.main:app --reload
 - Follow Python PEP 8 style for backend code
 - Components use shadcn/ui library
 - API endpoints follow RESTful conventions
+
+### Backend Logic Flow
+- Endpoints in /app/api must only call services.
+- Services in /app/services contain business logic and orchestrate calls to one or more repositories to fulfill a use case. For example, UserService would call both UserRepository and DepartmentRepository to build a detailed user response.
+- Repositories in /app/database are responsible only for database queries.
+
+### Frontend API Integration
+- **Server-Side First**: Prioritize server-side data fetching using server actions for SSR/SEO benefits
+- **1:1 Endpoint Mapping**: Each frontend API function corresponds directly to a backend endpoint
+- **Type Safety**: All API interactions use TypeScript interfaces matching backend Pydantic schemas
+- **Centralized Configuration**: API base URLs and endpoints defined in `/src/api/constants/`
+- **Consistent Error Handling**: Standardized `ApiResponse<T>` format across all API calls
+- **Authentication**: Automatic Clerk token injection via HTTP client
+- **Usage Patterns**:
+  - Use server actions (`/src/api/server-actions/`) for server components and SSR
+  - Use endpoint functions (`/src/api/endpoints/`) for client-side interactions when needed
+  - All API types are defined in `/src/api/types/` and exported from index
 
 ## Testing Commands
 ```bash

--- a/frontend/src/api/README.md
+++ b/frontend/src/api/README.md
@@ -1,0 +1,81 @@
+# API Layer
+
+This directory contains the complete API integration layer for the HR Evaluation System frontend.
+
+## Overview
+
+The API layer provides a structured approach to communicate with the FastAPI backend, with a focus on server-side rendering (SSR) and type safety.
+
+## Folder Structure
+
+```
+src/api/
+├── client/           # HTTP client configuration
+├── constants/        # API configuration constants
+├── endpoints/        # API endpoint functions (1:1 with backend routes)
+├── server-actions/   # Next.js server actions for SSR
+├── types/           # TypeScript interfaces matching backend schemas
+└── README.md        # This file
+```
+
+## Key Features
+
+- **Type Safety**: Full TypeScript support with interfaces matching backend schemas
+- **Server-Side Focus**: Designed for Next.js App Router SSR (not client-side)
+- **1:1 Mapping**: Each frontend API function corresponds to a backend endpoint
+- **Centralized Configuration**: Environment-based API configuration
+- **Error Handling**: Consistent error handling across all API calls
+- **Authentication**: Integrated Clerk authentication with automatic token handling
+
+## Usage Patterns
+
+### For Server Components (Recommended)
+```typescript
+import { getUsersAction } from '@/api/server-actions';
+
+export default async function UsersPage() {
+  const result = await getUsersAction({ page: 1, limit: 10 });
+  
+  if (!result.success) {
+    return <div>Error: {result.error}</div>;
+  }
+  
+  return <div>{result.data.users.map(user => ...)}</div>;
+}
+```
+
+### For Client Components (when needed)
+```typescript
+'use client';
+import { usersApi } from '@/api/endpoints';
+
+export function UsersList() {
+  const [users, setUsers] = useState([]);
+  
+  useEffect(() => {
+    usersApi.getUsers().then(result => {
+      if (result.success) {
+        setUsers(result.data.users);
+      }
+    });
+  }, []);
+  
+  return <div>{users.map(user => ...)}</div>;
+}
+```
+
+## Environment Variables
+
+Add these to your `.env.local`:
+
+```
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000/api/v1
+```
+
+## Architecture Principles
+
+1. **Server-First**: Prioritize server-side data fetching for better SEO and performance
+2. **Type Safety**: All API interactions are fully typed
+3. **Error Consistency**: Standardized error handling across all endpoints
+4. **Authentication**: Automatic token handling with Clerk integration
+5. **Separation of Concerns**: Clear separation between API logic and UI components

--- a/frontend/src/api/client/README.md
+++ b/frontend/src/api/client/README.md
@@ -1,0 +1,68 @@
+# HTTP Client
+
+This directory contains the HTTP client configuration for API communication.
+
+## Files
+
+### `http-client.ts`
+A wrapper around the Fetch API with the following features:
+
+- **Authentication**: Automatic Clerk token injection
+- **Error Handling**: Consistent error response formatting
+- **Type Safety**: Full TypeScript support with generics
+- **Base URL Management**: Environment-based API base URL configuration
+- **Request/Response Intercepting**: Built-in request and response processing
+
+## Usage
+
+### Basic Usage
+```typescript
+import { getHttpClient } from '@/api/client/http-client';
+
+const httpClient = getHttpClient();
+
+// GET request
+const response = await httpClient.get<UserResponse>('/users/123');
+
+// POST request
+const response = await httpClient.post<UserResponse>('/users', userData);
+```
+
+### Response Format
+All HTTP client methods return a standardized `ApiResponse<T>`:
+
+```typescript
+interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+}
+```
+
+### Example
+```typescript
+const response = await httpClient.get<User>('/users/123');
+
+if (response.success && response.data) {
+  console.log('User:', response.data);
+} else {
+  console.error('Error:', response.error);
+}
+```
+
+## Configuration
+
+The HTTP client automatically:
+- Uses `NEXT_PUBLIC_API_BASE_URL` environment variable for base URL
+- Adds Clerk authentication tokens to requests
+- Sets appropriate Content-Type headers
+- Handles JSON parsing and error responses
+
+## Error Handling
+
+The client provides consistent error handling:
+- Network errors are caught and wrapped
+- HTTP error status codes are handled
+- Authentication failures are properly formatted
+- Response parsing errors are managed

--- a/frontend/src/api/client/http-client.ts
+++ b/frontend/src/api/client/http-client.ts
@@ -1,0 +1,138 @@
+import { auth } from '@clerk/nextjs/server';
+
+export interface ApiResponse<T = any> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+}
+
+export interface RequestConfig {
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+  headers?: Record<string, string>;
+  body?: any;
+}
+
+class HttpClient {
+  private baseUrl: string;
+  private defaultHeaders: Record<string, string>;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+    this.defaultHeaders = {
+      'Content-Type': 'application/json',
+    };
+  }
+
+  private async getAuthHeaders(): Promise<Record<string, string>> {
+    try {
+      const { getToken } = auth();
+      const token = await getToken();
+      
+      if (token) {
+        return {
+          'Authorization': `Bearer ${token}`,
+        };
+      }
+    } catch (error) {
+      console.warn('Failed to get auth token:', error);
+    }
+    
+    return {};
+  }
+
+  private async buildHeaders(customHeaders?: Record<string, string>): Promise<Record<string, string>> {
+    const authHeaders = await this.getAuthHeaders();
+    
+    return {
+      ...this.defaultHeaders,
+      ...authHeaders,
+      ...customHeaders,
+    };
+  }
+
+  private async handleResponse<T>(response: Response): Promise<ApiResponse<T>> {
+    const contentType = response.headers.get('content-type');
+    let data: any;
+
+    if (contentType && contentType.includes('application/json')) {
+      data = await response.json();
+    } else {
+      data = await response.text();
+    }
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: data?.message || data?.error || `HTTP ${response.status}: ${response.statusText}`,
+        data: data,
+      };
+    }
+
+    return {
+      success: true,
+      data: data,
+    };
+  }
+
+  async request<T = any>(
+    endpoint: string,
+    config: RequestConfig = {}
+  ): Promise<ApiResponse<T>> {
+    const { method = 'GET', headers: customHeaders, body } = config;
+    
+    try {
+      const url = `${this.baseUrl}${endpoint}`;
+      const headers = await this.buildHeaders(customHeaders);
+      
+      const requestConfig: RequestInit = {
+        method,
+        headers,
+      };
+
+      if (body && method !== 'GET') {
+        requestConfig.body = typeof body === 'string' ? body : JSON.stringify(body);
+      }
+
+      const response = await fetch(url, requestConfig);
+      return await this.handleResponse<T>(response);
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Network error occurred',
+      };
+    }
+  }
+
+  async get<T = any>(endpoint: string, headers?: Record<string, string>): Promise<ApiResponse<T>> {
+    return this.request<T>(endpoint, { method: 'GET', headers });
+  }
+
+  async post<T = any>(endpoint: string, body?: any, headers?: Record<string, string>): Promise<ApiResponse<T>> {
+    return this.request<T>(endpoint, { method: 'POST', body, headers });
+  }
+
+  async put<T = any>(endpoint: string, body?: any, headers?: Record<string, string>): Promise<ApiResponse<T>> {
+    return this.request<T>(endpoint, { method: 'PUT', body, headers });
+  }
+
+  async delete<T = any>(endpoint: string, headers?: Record<string, string>): Promise<ApiResponse<T>> {
+    return this.request<T>(endpoint, { method: 'DELETE', headers });
+  }
+
+  async patch<T = any>(endpoint: string, body?: any, headers?: Record<string, string>): Promise<ApiResponse<T>> {
+    return this.request<T>(endpoint, { method: 'PATCH', body, headers });
+  }
+}
+
+let httpClientInstance: HttpClient | null = null;
+
+export function getHttpClient(): HttpClient {
+  if (!httpClientInstance) {
+    const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000/api/v1';
+    httpClientInstance = new HttpClient(baseUrl);
+  }
+  return httpClientInstance;
+}
+
+export default HttpClient;

--- a/frontend/src/api/constants/README.md
+++ b/frontend/src/api/constants/README.md
@@ -1,0 +1,87 @@
+# API Constants
+
+This directory contains configuration constants and endpoint definitions.
+
+## Files
+
+### `config.ts`
+Central configuration for all API-related constants including:
+
+- **API_CONFIG**: Base configuration (URLs, timeouts, retry settings)
+- **API_ENDPOINTS**: All backend endpoint paths organized by resource
+- **HTTP_STATUS**: HTTP status code constants
+- **ERROR_MESSAGES**: Standardized error messages
+
+## Usage
+
+### API Endpoints
+```typescript
+import { API_ENDPOINTS } from '@/api/constants/config';
+
+// Use endpoint constants
+const userEndpoint = API_ENDPOINTS.USERS.BY_ID('user-123');
+// Results in: '/users/user-123'
+
+const listEndpoint = API_ENDPOINTS.USERS.LIST;
+// Results in: '/users'
+```
+
+### Configuration
+```typescript
+import { API_CONFIG } from '@/api/constants/config';
+
+// Access configuration
+console.log(API_CONFIG.BASE_URL); // http://localhost:8000/api/v1
+console.log(API_CONFIG.TIMEOUT);  // 30000
+```
+
+### HTTP Status Codes
+```typescript
+import { HTTP_STATUS } from '@/api/constants/config';
+
+if (response.status === HTTP_STATUS.UNAUTHORIZED) {
+  // Handle unauthorized
+}
+```
+
+### Error Messages
+```typescript
+import { ERROR_MESSAGES } from '@/api/constants/config';
+
+return {
+  success: false,
+  error: ERROR_MESSAGES.UNAUTHORIZED
+};
+```
+
+## Endpoint Organization
+
+Endpoints are organized by resource type:
+
+- `AUTH`: Authentication endpoints
+- `USERS`: User management endpoints  
+- `DEPARTMENTS`: Department endpoints
+- `ROLES`: Role management endpoints
+- `STAGES`: Stage/level endpoints
+- `EVALUATION_PERIODS`: Evaluation period endpoints
+- `GOALS`: Goal management endpoints
+- `GOAL_CATEGORIES`: Goal category endpoints
+- `COMPETENCIES`: Competency endpoints
+- `SELF_ASSESSMENTS`: Self-assessment endpoints
+- `SUPERVISOR_REVIEWS`: Supervisor review endpoints
+- `SUPERVISOR_FEEDBACKS`: Supervisor feedback endpoints
+
+## Dynamic Endpoints
+
+Many endpoints accept parameters:
+
+```typescript
+// Static endpoint
+API_ENDPOINTS.USERS.LIST // '/users'
+
+// Dynamic endpoint with ID
+API_ENDPOINTS.USERS.BY_ID('123') // '/users/123'
+
+// Dynamic endpoint with multiple params
+API_ENDPOINTS.GOALS.BY_USER('user-123') // '/goals/user/user-123'
+```

--- a/frontend/src/api/constants/config.ts
+++ b/frontend/src/api/constants/config.ts
@@ -1,0 +1,147 @@
+export const API_CONFIG = {
+  BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000/api/v1',
+  TIMEOUT: 30000, // 30 seconds
+  RETRY_ATTEMPTS: 3,
+  RETRY_DELAY: 1000, // 1 second
+} as const;
+
+export const API_ENDPOINTS = {
+  // Auth endpoints
+  AUTH: {
+    SIGNIN: '/auth/signin',
+    SIGNOUT: '/auth/signout',
+    REFRESH: '/auth/refresh',
+    CURRENT_USER: '/auth/current-user',
+  },
+  
+  // User endpoints
+  USERS: {
+    LIST: '/users',
+    BY_ID: (id: string) => `/users/${id}`,
+    CREATE: '/users',
+    UPDATE: (id: string) => `/users/${id}`,
+    DELETE: (id: string) => `/users/${id}`,
+  },
+  
+  // Department endpoints
+  DEPARTMENTS: {
+    LIST: '/departments',
+    BY_ID: (id: string) => `/departments/${id}`,
+    CREATE: '/departments',
+    UPDATE: (id: string) => `/departments/${id}`,
+    DELETE: (id: string) => `/departments/${id}`,
+  },
+  
+  // Role endpoints
+  ROLES: {
+    LIST: '/roles',
+    BY_ID: (id: string) => `/roles/${id}`,
+    CREATE: '/roles',
+    UPDATE: (id: string) => `/roles/${id}`,
+    DELETE: (id: string) => `/roles/${id}`,
+  },
+  
+  // Stage endpoints
+  STAGES: {
+    LIST: '/stages',
+    BY_ID: (id: string) => `/stages/${id}`,
+    CREATE: '/stages',
+    UPDATE: (id: string) => `/stages/${id}`,
+    DELETE: (id: string) => `/stages/${id}`,
+  },
+  
+  // Evaluation Period endpoints
+  EVALUATION_PERIODS: {
+    LIST: '/evaluation-periods',
+    BY_ID: (id: string) => `/evaluation-periods/${id}`,
+    CREATE: '/evaluation-periods',
+    UPDATE: (id: string) => `/evaluation-periods/${id}`,
+    DELETE: (id: string) => `/evaluation-periods/${id}`,
+    CURRENT: '/evaluation-periods/current',
+  },
+  
+  // Goal endpoints
+  GOALS: {
+    LIST: '/goals',
+    BY_ID: (id: string) => `/goals/${id}`,
+    CREATE: '/goals',
+    UPDATE: (id: string) => `/goals/${id}`,
+    DELETE: (id: string) => `/goals/${id}`,
+    BY_USER: (userId: string) => `/goals/user/${userId}`,
+    BY_PERIOD: (periodId: string) => `/goals/period/${periodId}`,
+  },
+  
+  // Goal Category endpoints
+  GOAL_CATEGORIES: {
+    LIST: '/goal-categories',
+    BY_ID: (id: string) => `/goal-categories/${id}`,
+    CREATE: '/goal-categories',
+    UPDATE: (id: string) => `/goal-categories/${id}`,
+    DELETE: (id: string) => `/goal-categories/${id}`,
+  },
+  
+  // Competency endpoints
+  COMPETENCIES: {
+    LIST: '/competencies',
+    BY_ID: (id: string) => `/competencies/${id}`,
+    CREATE: '/competencies',
+    UPDATE: (id: string) => `/competencies/${id}`,
+    DELETE: (id: string) => `/competencies/${id}`,
+  },
+  
+  // Self Assessment endpoints
+  SELF_ASSESSMENTS: {
+    LIST: '/self-assessments',
+    BY_ID: (id: string) => `/self-assessments/${id}`,
+    CREATE: '/self-assessments',
+    UPDATE: (id: string) => `/self-assessments/${id}`,
+    DELETE: (id: string) => `/self-assessments/${id}`,
+    BY_USER: (userId: string) => `/self-assessments/user/${userId}`,
+    BY_PERIOD: (periodId: string) => `/self-assessments/period/${periodId}`,
+  },
+  
+  // Supervisor Review endpoints
+  SUPERVISOR_REVIEWS: {
+    LIST: '/supervisor-reviews',
+    BY_ID: (id: string) => `/supervisor-reviews/${id}`,
+    CREATE: '/supervisor-reviews',
+    UPDATE: (id: string) => `/supervisor-reviews/${id}`,
+    DELETE: (id: string) => `/supervisor-reviews/${id}`,
+    BY_SUPERVISOR: (supervisorId: string) => `/supervisor-reviews/supervisor/${supervisorId}`,
+    BY_EMPLOYEE: (employeeId: string) => `/supervisor-reviews/employee/${employeeId}`,
+  },
+  
+  // Supervisor Feedback endpoints
+  SUPERVISOR_FEEDBACKS: {
+    LIST: '/supervisor-feedbacks',
+    BY_ID: (id: string) => `/supervisor-feedbacks/${id}`,
+    CREATE: '/supervisor-feedbacks',
+    UPDATE: (id: string) => `/supervisor-feedbacks/${id}`,
+    DELETE: (id: string) => `/supervisor-feedbacks/${id}`,
+    BY_SUPERVISOR: (supervisorId: string) => `/supervisor-feedbacks/supervisor/${supervisorId}`,
+    BY_EMPLOYEE: (employeeId: string) => `/supervisor-feedbacks/employee/${employeeId}`,
+  },
+} as const;
+
+export const HTTP_STATUS = {
+  OK: 200,
+  CREATED: 201,
+  NO_CONTENT: 204,
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  CONFLICT: 409,
+  UNPROCESSABLE_ENTITY: 422,
+  INTERNAL_SERVER_ERROR: 500,
+} as const;
+
+export const ERROR_MESSAGES = {
+  NETWORK_ERROR: 'Network error occurred. Please check your connection.',
+  UNAUTHORIZED: 'You are not authorized to access this resource.',
+  FORBIDDEN: 'Access denied. You do not have permission to perform this action.',
+  NOT_FOUND: 'The requested resource was not found.',
+  VALIDATION_ERROR: 'Please check your input and try again.',
+  INTERNAL_ERROR: 'An internal error occurred. Please try again later.',
+  TIMEOUT: 'Request timed out. Please try again.',
+} as const;

--- a/frontend/src/api/endpoints/README.md
+++ b/frontend/src/api/endpoints/README.md
@@ -1,0 +1,120 @@
+# API Endpoints
+
+This directory contains functions that directly map to backend API endpoints (1:1 relationship).
+
+## Files
+
+### `users.ts`
+User management API functions:
+- `getUsers()`: Get paginated list of users
+- `getUserById()`: Get specific user by ID
+- `createUser()`: Create new user
+- `updateUser()`: Update existing user
+- `deleteUser()`: Delete user
+- `getUserProfile()`: Get user profile information
+
+### `index.ts`
+Re-exports all endpoint APIs for convenient importing
+
+## Usage Patterns
+
+### Basic Usage
+```typescript
+import { authApi, usersApi } from '@/api/endpoints';
+
+// Authentication
+const signInResult = await authApi.signIn({ clerk_token: 'token123' });
+const currentUser = await authApi.getCurrentUser();
+
+// User Management
+const users = await usersApi.getUsers({ page: 1, limit: 10 });
+const user = await usersApi.getUserById('user-123');
+```
+
+### Error Handling
+```typescript
+const result = await usersApi.getUserById('user-123');
+
+if (result.success && result.data) {
+  console.log('User found:', result.data);
+} else {
+  console.error('Error:', result.error);
+}
+```
+
+### With TypeScript
+```typescript
+import type { UserCreate, ApiResponse, UserDetailResponse } from '@/api/types';
+
+const newUser: UserCreate = {
+  name: 'John Doe',
+  email: 'john@example.com',
+  // ... other fields
+};
+
+const result: ApiResponse<UserDetailResponse> = await usersApi.createUser(newUser);
+```
+
+## Design Principles
+
+### 1:1 Backend Mapping
+Each function corresponds directly to a backend endpoint:
+```typescript
+// Frontend: usersApi.getUserById('123')
+// Backend:  GET /api/v1/users/123
+
+// Frontend: usersApi.createUser(userData)
+// Backend:  POST /api/v1/users
+```
+
+### Consistent Return Format
+All functions return the same `ApiResponse<T>` structure:
+```typescript
+interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+}
+```
+
+### Type Safety
+All functions are fully typed with:
+- Input parameter types
+- Response data types
+- Error handling types
+
+### Authentication
+Functions automatically include authentication headers when available through the HTTP client.
+
+## When to Use
+
+**Use endpoint functions when:**
+- Building client-side functionality
+- Need direct API access in components
+- Working with form submissions
+- Implementing real-time features
+
+**Consider server actions instead when:**
+- Implementing server-side rendering (SSR)
+- Pre-loading data for pages
+- SEO is important
+- Want to reduce client-side JavaScript
+
+## Adding New Endpoints
+
+1. Define types in `/types/` directory
+2. Add endpoint constants to `/constants/config.ts`
+3. Create endpoint functions in appropriate file
+4. Add to index.ts exports
+5. Create corresponding server actions if needed
+
+## Error Handling
+
+All endpoint functions handle errors consistently:
+- Network errors
+- HTTP status errors
+- JSON parsing errors
+- Authentication failures
+
+Errors are returned in the standardized format rather than thrown as exceptions.

--- a/frontend/src/api/endpoints/index.ts
+++ b/frontend/src/api/endpoints/index.ts
@@ -1,0 +1,2 @@
+// Re-export all endpoint APIs
+export { usersApi } from './users';

--- a/frontend/src/api/endpoints/users.ts
+++ b/frontend/src/api/endpoints/users.ts
@@ -1,0 +1,59 @@
+import { getHttpClient } from '../client/http-client';
+import { API_ENDPOINTS } from '../constants/config';
+import type {
+  UserList,
+  UserDetailResponse,
+  UserCreate,
+  UserUpdate,
+  UserProfile,
+  PaginationParams,
+  ApiResponse,
+  UUID,
+} from '../types';
+
+const httpClient = getHttpClient();
+
+export const usersApi = {
+  /**
+   * Get all users with optional pagination
+   */
+  getUsers: async (params?: PaginationParams): Promise<ApiResponse<UserList>> => {
+    const queryParams = new URLSearchParams();
+    if (params?.page) queryParams.append('page', params.page.toString());
+    if (params?.limit) queryParams.append('limit', params.limit.toString());
+    
+    const endpoint = queryParams.toString() 
+      ? `${API_ENDPOINTS.USERS.LIST}?${queryParams.toString()}`
+      : API_ENDPOINTS.USERS.LIST;
+    
+    return httpClient.get<UserList>(endpoint);
+  },
+
+  /**
+   * Get a specific user by ID
+   */
+  getUserById: async (userId: UUID): Promise<ApiResponse<UserDetailResponse>> => {
+    return httpClient.get<UserDetailResponse>(API_ENDPOINTS.USERS.BY_ID(userId));
+  },
+
+  /**
+   * Create a new user
+   */
+  createUser: async (data: UserCreate): Promise<ApiResponse<UserDetailResponse>> => {
+    return httpClient.post<UserDetailResponse>(API_ENDPOINTS.USERS.CREATE, data);
+  },
+
+  /**
+   * Update an existing user
+   */
+  updateUser: async (userId: UUID, data: UserUpdate): Promise<ApiResponse<UserDetailResponse>> => {
+    return httpClient.put<UserDetailResponse>(API_ENDPOINTS.USERS.UPDATE(userId), data);
+  },
+
+  /**
+   * Delete a user
+   */
+  deleteUser: async (userId: UUID): Promise<ApiResponse<void>> => {
+    return httpClient.delete<void>(API_ENDPOINTS.USERS.DELETE(userId));
+  },
+};

--- a/frontend/src/api/server-actions/README.md
+++ b/frontend/src/api/server-actions/README.md
@@ -1,0 +1,169 @@
+# Server Actions
+
+This directory contains Next.js server actions for server-side data fetching and mutations.
+
+## Files
+
+### `users.ts`
+User management server actions:
+- `getUsersAction()`: Get paginated users for SSR
+- `getUserByIdAction()`: Get specific user for SSR
+- `createUserAction()`: Create user on server
+- `updateUserAction()`: Update user on server
+- `deleteUserAction()`: Delete user on server
+### `index.ts`
+Re-exports all server actions
+
+## Usage
+
+### In Server Components (Recommended)
+```typescript
+import { getUsersAction, getCurrentUserAction } from '@/api/server-actions';
+
+export default async function UsersPage() {
+  // These run on the server during SSR
+  const [usersResult, currentUserResult] = await Promise.all([
+    getUsersAction({ page: 1, limit: 10 }),
+    getCurrentUserAction()
+  ]);
+
+  if (!usersResult.success) {
+    return <div>Error loading users: {usersResult.error}</div>;
+  }
+
+  return (
+    <div>
+      <h1>Welcome, {currentUserResult.data?.name}</h1>
+      <UsersList users={usersResult.data.users} />
+    </div>
+  );
+}
+```
+
+### In Client Components (Form Actions)
+```typescript
+'use client';
+import { createUserAction } from '@/api/server-actions';
+
+export function CreateUserForm() {
+  async function handleSubmit(formData: FormData) {
+    const userData = {
+      name: formData.get('name') as string,
+      email: formData.get('email') as string,
+      // ... other fields
+    };
+
+    const result = await createUserAction(userData);
+    
+    if (result.success) {
+      // Handle success
+    } else {
+      // Handle error
+    }
+  }
+
+  return (
+    <form action={handleSubmit}>
+      {/* form fields */}
+    </form>
+  );
+}
+```
+
+### With useFormState Hook
+```typescript
+'use client';
+import { useFormState } from 'react-dom';
+import { createUserAction } from '@/api/server-actions';
+
+export function CreateUserForm() {
+  const [state, formAction] = useFormState(createUserAction, null);
+
+  return (
+    <form action={formAction}>
+      {state?.error && <div className="error">{state.error}</div>}
+      {/* form fields */}
+    </form>
+  );
+}
+```
+
+## Key Features
+
+### Server-Side Execution
+- Run on the server, not in the browser
+- Better for SEO and initial page load
+- Reduce client-side JavaScript bundle size
+- Direct database/API access without CORS issues
+
+### Type Safety
+All server actions are fully typed:
+```typescript
+export async function getUserByIdAction(userId: UUID): Promise<{
+  success: boolean;
+  data?: UserDetailResponse;
+  error?: string;
+}> {
+  // Implementation
+}
+```
+
+### Error Handling
+Consistent error handling pattern:
+```typescript
+try {
+  const response = await apiCall();
+  
+  if (!response.success) {
+    return { success: false, error: response.error };
+  }
+  
+  return { success: true, data: response.data };
+} catch (error) {
+  console.error('Server action error:', error);
+  return { success: false, error: 'Unexpected error occurred' };
+}
+```
+
+### Authentication
+Server actions automatically handle authentication through the HTTP client and Clerk integration.
+
+## When to Use Server Actions
+
+**Preferred for:**
+- Server-side rendering (SSR)
+- Initial page data loading
+- SEO-critical pages
+- Form submissions
+- Data mutations that should happen on server
+
+**Consider endpoint functions instead for:**
+- Client-side interactivity
+- Real-time features
+- Dynamic client-side updates
+- When you need more control over caching
+
+## Benefits Over Client-Side Fetching
+
+1. **Performance**: Faster initial page loads
+2. **SEO**: Search engines can see the content
+3. **Security**: Sensitive operations stay on server
+4. **Bundle Size**: Less JavaScript sent to client
+5. **Network**: Fewer round trips for initial render
+
+## Best Practices
+
+1. **Error Handling**: Always wrap in try-catch
+2. **Type Safety**: Use proper TypeScript types
+3. **Validation**: Validate inputs on server side
+4. **Logging**: Log errors for debugging
+5. **Consistent Returns**: Use standardized response format
+
+## Adding New Server Actions
+
+1. Create the action function with 'use server' directive
+2. Add proper TypeScript types
+3. Implement error handling
+4. Add to appropriate file (auth.ts, users.ts, etc.)
+5. Export from index.ts
+6. Update documentation

--- a/frontend/src/api/server-actions/index.ts
+++ b/frontend/src/api/server-actions/index.ts
@@ -1,0 +1,2 @@
+// Re-export all server actions
+export * from './users';

--- a/frontend/src/api/server-actions/users.ts
+++ b/frontend/src/api/server-actions/users.ts
@@ -1,0 +1,166 @@
+'use server';
+
+import { usersApi } from '../endpoints/users';
+import type { 
+  UserList, 
+  UserDetailResponse, 
+  UserCreate, 
+  UserUpdate, 
+  UserProfile,
+  PaginationParams,
+  UUID 
+} from '../types';
+
+/**
+ * Server action to get all users with pagination
+ * This function runs on the server side for SSR
+ */
+export async function getUsersAction(params?: PaginationParams): Promise<{
+  success: boolean;
+  data?: UserList;
+  error?: string;
+}> {
+  try {
+    const response = await usersApi.getUsers(params);
+    
+    if (!response.success || !response.data) {
+      return {
+        success: false,
+        error: response.error || 'Failed to fetch users',
+      };
+    }
+    
+    return {
+      success: true,
+      data: response.data,
+    };
+  } catch (error) {
+    console.error('Get users action error:', error);
+    return {
+      success: false,
+      error: 'An unexpected error occurred while fetching users',
+    };
+  }
+}
+
+/**
+ * Server action to get a specific user by ID
+ */
+export async function getUserByIdAction(userId: UUID): Promise<{
+  success: boolean;
+  data?: UserDetailResponse;
+  error?: string;
+}> {
+  try {
+    const response = await usersApi.getUserById(userId);
+    
+    if (!response.success || !response.data) {
+      return {
+        success: false,
+        error: response.error || 'Failed to fetch user',
+      };
+    }
+    
+    return {
+      success: true,
+      data: response.data,
+    };
+  } catch (error) {
+    console.error('Get user by ID action error:', error);
+    return {
+      success: false,
+      error: 'An unexpected error occurred while fetching user',
+    };
+  }
+}
+
+/**
+ * Server action to create a new user
+ */
+export async function createUserAction(userData: UserCreate): Promise<{
+  success: boolean;
+  data?: UserDetailResponse;
+  error?: string;
+}> {
+  try {
+    const response = await usersApi.createUser(userData);
+    
+    if (!response.success || !response.data) {
+      return {
+        success: false,
+        error: response.error || 'Failed to create user',
+      };
+    }
+    
+    return {
+      success: true,
+      data: response.data,
+    };
+  } catch (error) {
+    console.error('Create user action error:', error);
+    return {
+      success: false,
+      error: 'An unexpected error occurred while creating user',
+    };
+  }
+}
+
+/**
+ * Server action to update an existing user
+ */
+export async function updateUserAction(userId: UUID, updateData: UserUpdate): Promise<{
+  success: boolean;
+  data?: UserDetailResponse;
+  error?: string;
+}> {
+  try {
+    const response = await usersApi.updateUser(userId, updateData);
+    
+    if (!response.success || !response.data) {
+      return {
+        success: false,
+        error: response.error || 'Failed to update user',
+      };
+    }
+    
+    return {
+      success: true,
+      data: response.data,
+    };
+  } catch (error) {
+    console.error('Update user action error:', error);
+    return {
+      success: false,
+      error: 'An unexpected error occurred while updating user',
+    };
+  }
+}
+
+/**
+ * Server action to delete a user
+ */
+export async function deleteUserAction(userId: UUID): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  try {
+    const response = await usersApi.deleteUser(userId);
+    
+    if (!response.success) {
+      return {
+        success: false,
+        error: response.error || 'Failed to delete user',
+      };
+    }
+    
+    return {
+      success: true,
+    };
+  } catch (error) {
+    console.error('Delete user action error:', error);
+    return {
+      success: false,
+      error: 'An unexpected error occurred while deleting user',
+    };
+  }
+}

--- a/frontend/src/api/types/README.md
+++ b/frontend/src/api/types/README.md
@@ -1,0 +1,108 @@
+# API Types
+
+This directory contains TypeScript interfaces and types that match the backend API schemas.
+
+## Files
+
+### `common.ts`
+Common types used across multiple resources:
+- `UUID`: String-based UUID type
+- `SubmissionStatus`: Enum for draft/submitted states
+- `Permission`: Permission interface
+- `PaginationParams`: Pagination parameters
+- `PaginatedResponse<T>`: Generic paginated response
+- `BaseResponse`: Base API response structure
+- `ErrorResponse`: Error response structure
+
+### `auth.ts`
+Authentication-related types:
+- `SignInRequest`: Clerk token signin request
+- `SignInResponse`: Signin response with user and tokens
+- `TokenData`: Access and refresh token structure
+- `UserAuthResponse`: Authenticated user information
+- `TokenVerifyRequest/Response`: Token verification types
+- `LogoutResponse`: Logout response
+
+### `user.ts`
+User management types:
+- `UserStatus`: Enum for user status (active, inactive, pending)
+- `Department`, `DepartmentDetail`: Department information
+- `Stage`, `StageDetail`: User stage/level information
+- `Role`, `RoleDetail`: Role and permission information
+- `User*`: Various user-related interfaces (create, update, detail, etc.)
+
+### `index.ts`
+Re-exports all types for convenient importing
+
+## Usage
+
+### Import Specific Types
+```typescript
+import { UserDetailResponse, Department, UUID } from '@/api/types';
+```
+
+### Import All Types
+```typescript
+import type * as ApiTypes from '@/api/types';
+```
+
+### Type Usage Examples
+
+#### User Creation
+```typescript
+import { UserCreate, UserStatus } from '@/api/types';
+
+const newUser: UserCreate = {
+  name: 'John Doe',
+  email: 'john@example.com',
+  employee_code: 'EMP001',
+  clerk_user_id: 'clerk_123',
+  department_id: 'dept-uuid',
+  stage_id: 'stage-uuid',
+  status: UserStatus.PENDING_APPROVAL
+};
+```
+
+#### API Response Handling
+```typescript
+import { ApiResponse, UserDetailResponse } from '@/api/types';
+
+function handleUserResponse(response: ApiResponse<UserDetailResponse>) {
+  if (response.success && response.data) {
+    console.log('User:', response.data.name);
+    console.log('Department:', response.data.department.name);
+  }
+}
+```
+
+#### Pagination
+```typescript
+import { PaginationParams, PaginatedResponse, UserDetailResponse } from '@/api/types';
+
+const params: PaginationParams = { page: 1, limit: 10 };
+const response: PaginatedResponse<UserDetailResponse> = {
+  items: users,
+  total: 100,
+  page: 1,
+  limit: 10,
+  pages: 10
+};
+```
+
+## Type Safety Benefits
+
+1. **Compile-time Validation**: Catch type errors before runtime
+2. **IDE Support**: Auto-completion and IntelliSense
+3. **Refactoring Safety**: Changes propagate throughout codebase
+4. **Documentation**: Types serve as inline documentation
+5. **Backend Consistency**: Types match backend schemas exactly
+
+## Maintenance
+
+When backend schemas change:
+1. Update the corresponding TypeScript interfaces
+2. Run type checking: `npm run type-check`
+3. Update any affected code
+4. Test the changes
+
+The types in this directory should always match the backend Pydantic schemas to ensure consistency across the full stack.

--- a/frontend/src/api/types/auth.ts
+++ b/frontend/src/api/types/auth.ts
@@ -1,0 +1,37 @@
+import { UUID } from './common';
+import { UserDetailResponse } from './user';
+
+export interface SignInRequest {
+  clerk_token: string;
+}
+
+export interface TokenData {
+  access_token: string;
+  refresh_token: string;
+}
+
+export interface SignInResponse {
+  user: UserDetailResponse;
+  token: TokenData;
+}
+
+export interface UserAuthResponse {
+  id: UUID;
+  email: string;
+  name: string;
+  clerk_user_id: string;
+}
+
+export interface TokenVerifyRequest {
+  token: string;
+}
+
+export interface TokenVerifyResponse {
+  valid: boolean;
+  user?: UserAuthResponse;
+  error?: string;
+}
+
+export interface LogoutResponse {
+  message: string;
+}

--- a/frontend/src/api/types/common.ts
+++ b/frontend/src/api/types/common.ts
@@ -1,0 +1,41 @@
+export type UUID = string;
+
+export enum SubmissionStatus {
+  DRAFT = 'draft',
+  SUBMITTED = 'submitted',
+}
+
+export interface Permission {
+  name: string;
+  description: string;
+}
+
+export interface PaginationParams {
+  page?: number;
+  limit?: number;
+}
+
+export interface PaginatedResponse<T> {
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
+  pages: number;
+}
+
+export interface BaseResponse {
+  success: boolean;
+  message?: string;
+}
+
+export interface ErrorResponse {
+  error: boolean;
+  message: string;
+  status_code: number;
+}
+
+export interface HealthCheckResponse {
+  status: string;
+  timestamp: string;
+  version: string;
+}

--- a/frontend/src/api/types/index.ts
+++ b/frontend/src/api/types/index.ts
@@ -1,0 +1,16 @@
+// Common types
+export * from './common';
+
+// Auth types
+export * from './auth';
+
+// User types
+export * from './user';
+
+// API Response wrapper type
+export interface ApiResponse<T = any> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+}

--- a/frontend/src/api/types/user.ts
+++ b/frontend/src/api/types/user.ts
@@ -1,0 +1,158 @@
+import { UUID, Permission, PaginatedResponse } from './common';
+
+export enum UserStatus {
+  PENDING_APPROVAL = 'pending_approval',
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+}
+
+export interface Department {
+  id: UUID;
+  name: string;
+  description?: string;
+}
+
+export interface DepartmentDetail {
+  id: UUID;
+  name: string;
+  description?: string;
+  created_at: string;
+  updated_at: string;
+  user_count?: number;
+  manager_id?: UUID;
+  manager_name?: string;
+  users?: PaginatedResponse<UserDetailResponse>;
+}
+
+export interface DepartmentCreate {
+  name: string;
+  description?: string;
+}
+
+export interface DepartmentUpdate {
+  name?: string;
+  description?: string;
+}
+
+export interface Stage {
+  id: UUID;
+  name: string;
+  description?: string;
+}
+
+export interface StageDetail {
+  id: UUID;
+  name: string;
+  description?: string;
+  created_at: string;
+  updated_at: string;
+  user_count?: number;
+  competency_count?: number;
+  users?: PaginatedResponse<UserDetailResponse>;
+  competencies?: any[]; // TODO: Define Competency type
+}
+
+export interface StageCreate {
+  name: string;
+  description?: string;
+}
+
+export interface StageUpdate {
+  name?: string;
+  description?: string;
+}
+
+export interface Role {
+  id: number;
+  name: string;
+  description: string;
+}
+
+export interface RoleDetail {
+  id: number;
+  name: string;
+  description: string;
+  permissions: Permission[];
+  user_count?: number;
+}
+
+export interface RoleCreate {
+  name: string;
+  description: string;
+}
+
+export interface RoleUpdate {
+  name?: string;
+  description?: string;
+}
+
+export interface UserBase {
+  name: string;
+  email: string;
+  employee_code: string;
+  job_title?: string;
+}
+
+export interface UserCreate extends UserBase {
+  clerk_user_id: string;
+  department_id: UUID;
+  stage_id: UUID;
+  role_ids?: number[];
+  supervisor_id?: UUID;
+  status?: UserStatus;
+}
+
+export interface UserUpdate {
+  name?: string;
+  email?: string;
+  employee_code?: string;
+  job_title?: string;
+  department_id?: UUID;
+  stage_id?: UUID;
+  role_ids?: number[];
+  status?: UserStatus;
+}
+
+export interface UserInDB extends UserBase {
+  id: UUID;
+  clerk_user_id: string;
+  status: UserStatus;
+  department_id: UUID;
+  stage_id: UUID;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface User extends UserInDB {
+  department: Department;
+  stage: Stage;
+  roles: Role[];
+  supervisor?: UserDetailResponse;
+}
+
+export interface UserDetailResponse {
+  id: UUID;
+  clerk_user_id: string;
+  employee_code: string;
+  name: string;
+  email: string;
+  status: UserStatus;
+  job_title?: string;
+  department: Department;
+  stage: Stage;
+  roles: Role[];
+  supervisor?: UserDetailResponse;
+}
+
+export interface UserPaginatedResponse extends PaginatedResponse<UserDetailResponse> {
+  data: UserDetailResponse[];
+}
+
+export interface UserList {
+  users: UserDetailResponse[];
+  total: number;
+}
+
+export interface UserProfile extends UserDetailResponse {
+  // Additional profile-specific fields can be added here
+}


### PR DESCRIPTION
## Summary
フロントエンドにAPI統合レイヤーを導入。これには、Clerk認証を処理する再利用可能なHTTPクライアント、一元化されたエンドポイント管理、およびサーバーサイドデータフェッチのための明確な設計パターンを含む。

## Related Issues
Closes #N/A
Related to #N/A

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Code refactoring

## Changes Made
- Added a structured API layer to the frontend under `frontend/src/api`.
- Implemented a reusable `HttpClient` with automatic Clerk token injection (`http-client.ts`).
- Centralized all backend API endpoint definitions in `api/constants/config.ts`.
- Established a clear architecture for server-side data fetching (server actions) and client-side calls.
- Added comprehensive README documentation for the new API layer and its components.