### PR TITLE
fix: OpenAPI Documentation Authentication Integration

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -1,9 +1,44 @@
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from ...database.session import get_db_session
+from fastapi import APIRouter
 
 router = APIRouter(prefix="/auth", tags=["authentication"])
+
+@router.get("/dev-keys")
+async def get_dev_keys():
+    """
+    Get development API keys for testing different roles.
+    """
+    return {
+        "dev_keys": {
+            "admin": {
+                "key": "dev-admin-key",
+                "role": "admin",
+                "description": "Full access to all endpoints including admin operations"
+            },
+            "manager": {
+                "key": "dev-manager-key", 
+                "role": "manager",
+                "description": "Access to management operations and team oversight"
+            },
+            "supervisor": {
+                "key": "dev-supervisor-key",
+                "role": "supervisor", 
+                "description": "Access to supervisor operations and direct reports"
+            },
+            "employee": {
+                "key": "dev-employee-key",
+                "role": "employee",
+                "description": "Basic employee access to own data and evaluations"
+            }
+        },
+        "instructions": [
+            "1. Go to http://localhost:8000/docs",
+            "2. Click 'Authorize' button", 
+            "3. Enter one of the keys above based on the role you want to test",
+            "4. Click 'Authorize'",
+            "5. Test endpoints - access will be restricted based on the role"
+        ]
+    }
+
 
 @router.post("/logout") 
 async def logout():

--- a/backend/app/database/migrations/020_update_roles_seed.sql
+++ b/backend/app/database/migrations/020_update_roles_seed.sql
@@ -1,0 +1,8 @@
+-- Update default roles with Japanese names and descriptions
+INSERT INTO roles (id, name, description) VALUES 
+(1, 'admin', '管理者'),
+(2, 'manager', '部門マネジャー'), 
+(3, 'supervisor', '上司'), 
+(4, 'employee', '従業員'),
+(5, 'viewer', '閲覧者')
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, description = EXCLUDED.description; 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.openapi.utils import get_openapi
 import logging
 
 from .api.v1 import api_router
@@ -42,6 +43,68 @@ app.include_router(api_router)
 # Include webhooks at root level (without /api/v1 prefix)
 from .api.v1 import webhooks_router_root
 app.include_router(webhooks_router_root)
+
+def custom_openapi():
+    """
+    Custom OpenAPI schema with authentication configuration.
+    """
+    if app.openapi_schema:
+        return app.openapi_schema
+    
+    logger.info("Generating custom OpenAPI schema...")
+    
+    openapi_schema = get_openapi(
+        title="HR Evaluation System API",
+        version="1.0.0",
+        description="API for managing employee evaluations, goals, and performance reports",
+        routes=app.routes,
+    )
+    
+    # Add security schemes
+    openapi_schema["components"]["securitySchemes"] = {
+        "BearerAuth": {
+            "type": "http",
+            "scheme": "bearer",
+            "bearerFormat": "JWT",
+            "description": "Enter either:\n1. Development API keys:\n   - dev-admin-key (admin role)\n   - dev-manager-key (manager role)\n   - dev-supervisor-key (supervisor role)\n   - dev-employee-key (employee role)\n2. Your Clerk JWT token from the frontend application\n\nGet all dev keys from: GET /api/v1/auth/dev-keys"
+        }
+    }
+    
+    # Define public endpoints that don't require authentication
+    public_endpoints = {
+        "/",
+        "/health", 
+        "/api/v1/auth/signup/profile-options",
+        "/api/v1/auth/user/{clerk_user_id}",
+        "/api/v1/auth/signup",
+        "/api/v1/auth/logout",
+        "/api/v1/auth/dev-keys",
+        "/api/v1/users/exists/{clerk_user_id}",
+        "/api/v1/users/profile-options"
+    }
+    
+    # Apply security requirements to all endpoints
+    logger.info("OpenAPI paths found:")
+    for path, path_item in openapi_schema["paths"].items():
+        logger.info(f"  Path: {path}")
+        for method, method_data in path_item.items():
+            if isinstance(method_data, dict) and method.lower() in ["get", "post", "put", "patch", "delete"]:
+                if path in public_endpoints:
+                    # Public endpoints don't require auth
+                    method_data["security"] = []
+                    logger.info(f"    {method.upper()}: PUBLIC (no auth)")
+                else:
+                    # Protected endpoints require BearerAuth
+                    method_data["security"] = [{"BearerAuth": []}]
+                    logger.info(f"    {method.upper()}: PROTECTED (requires auth)")
+    
+    app.openapi_schema = openapi_schema
+    return app.openapi_schema
+
+# Clear any existing schema cache and assign our custom function
+app.openapi_schema = None
+app.openapi = custom_openapi
+logger.info("Custom OpenAPI function assigned successfully")
 
 @app.get("/", response_model=HealthCheckResponse)
 async def root():

--- a/backend/app/security/dependencies.py
+++ b/backend/app/security/dependencies.py
@@ -39,6 +39,39 @@ async def get_auth_context(
         # Get token from request
         token = credentials.credentials
         
+        # Check for development API keys
+        dev_keys = {
+            "dev-admin-key": {
+                "user_id": "00000000-0000-0000-0000-000000000001",
+                "clerk_user_id": "dev-admin",
+                "roles": [RoleInfo(id=1, name="admin", description="Development admin role")]
+            },
+            "dev-manager-key": {
+                "user_id": "00000000-0000-0000-0000-000000000002", 
+                "clerk_user_id": "dev-manager",
+                "roles": [RoleInfo(id=2, name="manager", description="Development manager role")]
+            },
+            "dev-supervisor-key": {
+                "user_id": "00000000-0000-0000-0000-000000000003",
+                "clerk_user_id": "dev-supervisor", 
+                "roles": [RoleInfo(id=3, name="supervisor", description="Development supervisor role")]
+            },
+            "dev-employee-key": {
+                "user_id": "00000000-0000-0000-0000-000000000004",
+                "clerk_user_id": "dev-employee",
+                "roles": [RoleInfo(id=4, name="employee", description="Development employee role")]
+            }
+        }
+        
+        if token in dev_keys:
+            from uuid import UUID
+            dev_user = dev_keys[token]
+            return AuthContext(
+                user_id=UUID(dev_user["user_id"]),
+                clerk_user_id=dev_user["clerk_user_id"],
+                roles=dev_user["roles"]
+            )
+        
         # Verify with Clerk and get user info
         auth_service = AuthService(session)
         auth_user = auth_service.get_user_from_token(token)


### PR DESCRIPTION
## Summary
- HR 評価システムに OpenAPI 認証統合を実装
- 開発者がロールベースの開発 API キーを使用して Swagger UI 経由で保護されたエンドポイントをテスト可能

## Problem Statement
Previously, developers could not test authenticated endpoints through the Swagger UI at `localhost:8000/docs` because there was no way to provide authentication tokens. This made API testing cumbersome and required using external tools like curl or Postman.

## Solution
Added comprehensive OpenAPI authentication support with:

1. **Custom OpenAPI Schema**: Enhanced the FastAPI application with custom OpenAPI generation that properly configures security schemes
2. **Role-Based Development Keys**: Created separate API keys for different user roles (admin, manager, supervisor, employee)
3. **Swagger UI Integration**: All protected endpoints now show the lock icon and "Available authorizations" section
4. **Public Endpoint Configuration**: Properly marked public endpoints to not require authentication

## Technical Changes

### Files Modified

#### 1. `backend/app/main.py`
- Added `custom_openapi()` function for custom OpenAPI schema generation
- Configured `BearerAuth` security scheme with detailed descriptions
- Implemented per-endpoint security configuration logic
- Added public endpoints list for auth-free access
- Enhanced OpenAPI description with dev key instructions

#### 2. `backend/app/security/dependencies.py`
- Extended `get_auth_context()` to support multiple development API keys
- Added role-based authentication mapping:
  - `dev-admin-key` → admin role
  - `dev-manager-key` → manager role  
  - `dev-supervisor-key` → supervisor role
  - `dev-employee-key` → employee role
- Each dev key returns appropriate `AuthContext` with role-specific permissions

#### 3. `backend/app/api/v1/auth.py`
- Simplified and modernized auth endpoints
- Added `GET /dev-keys` endpoint providing all role-based development keys
- Removed legacy single-key endpoint
- Added comprehensive usage instructions and role descriptions

#### 4. `backend/app/database/migrations/020_update_roles_seed.sql`
- Updated role seeding with Japanese descriptions
- Ensured consistent role IDs for development key mapping

## Features

### Role-Based Development Keys
```json
{
  "dev_keys": {
    "admin": {
      "key": "dev-admin-key",
      "role": "admin", 
      "description": "Full access to all endpoints including admin operations"
    },
    "manager": {
      "key": "dev-manager-key",
      "role": "manager",
      "description": "Access to management operations and team oversight"
    },
    "supervisor": {
      "key": "dev-supervisor-key", 
      "role": "supervisor",
      "description": "Access to supervisor operations and direct reports"
    },
    "employee": {
      "key": "dev-employee-key",
      "role": "employee", 
      "description": "Basic employee access to own data and evaluations"
    }
  }
}
```

### Usage Instructions
1. Visit `http://localhost:8000/docs` 
2. Get available keys from `GET /api/v1/auth/dev-keys`
3. Click "Authorize" button in Swagger UI
4. Enter role-appropriate dev key (e.g., `dev-admin-key`)
5. Test any protected endpoint with proper role-based access control

### OpenAPI Security Configuration
- All protected endpoints now show lock icon and "Available authorizations"
- Public endpoints (health, signup, dev-keys) explicitly marked as auth-free
- Clear descriptions guide users on authentication options
- Supports both development keys and production Clerk JWT tokens

## Benefits

1. **Developer Experience**: Seamless API testing through Swagger UI
2. **Role Testing**: Easy testing of role-based access control with different keys
3. **Documentation**: Self-documenting API with clear auth requirements
4. **Industry Standard**: Follows OpenAPI/Swagger authentication best practices
5. **Dual Support**: Works with both development keys and production authentication

## Testing

### Verification Steps
1. **Swagger UI Access**: All protected endpoints show lock icon
2. **Role-Based Testing**: Different keys provide appropriate access levels
3. **Public Endpoints**: Auth-free endpoints work without keys
4. **curl Compatibility**: All dev keys work with direct API calls

## Related Issues

Resolves: #90 - OpenAPI Documentation Authentication Integration