### PR TITLE
Fix: Profile Completion Button Error

### DIFF
--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -4,7 +4,7 @@ import logging
 
 from ..database.repositories.user_repo import UserRepository
 from ..database.repositories.department_repo import DepartmentRepository
-from ..database.repositories.stage_repository import StageRepository
+from ..database.repositories.stage_repo import StageRepository
 from ..database.repositories.role_repo import RoleRepository
 from ..database.models.user import User
 from ..schemas.auth import AuthUser

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -7,7 +7,7 @@ from cachetools import TTLCache
 
 from ..database.repositories.user_repo import UserRepository
 from ..database.repositories.department_repo import DepartmentRepository
-from ..database.repositories.stage_repository import StageRepository
+from ..database.repositories.stage_repo import StageRepository
 from ..database.repositories.role_repo import RoleRepository
 from ..database.models.user import User as UserModel, UserSupervisor
 from ..schemas.user import (

--- a/frontend/src/feature/profile/display/ProfileForm.tsx
+++ b/frontend/src/feature/profile/display/ProfileForm.tsx
@@ -268,6 +268,35 @@ export default function ProfileForm({ departments, stages, roles, users }: Profi
               </div>
             )}
 
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>氏名</FormLabel>
+                    <FormControl>
+                      <Input {...field} readOnly className="bg-gray-100" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>メールアドレス</FormLabel>
+                    <FormControl>
+                      <Input {...field} readOnly className="bg-gray-100" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
             <FormField
               control={form.control}
               name="employee_code"

--- a/frontend/src/feature/profile/display/ProfileForm.tsx
+++ b/frontend/src/feature/profile/display/ProfileForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useUser } from '@clerk/nextjs';
 import { useRouter } from 'next/navigation';
 import { useForm, type ControllerRenderProps } from 'react-hook-form';
@@ -97,8 +97,8 @@ export default function ProfileForm({ departments, stages, roles, users }: Profi
     resolver: zodResolver(profileFormSchema),
     mode: 'onChange', // Enable real-time validation
     defaultValues: {
-      name: '',
-      email: '',
+      name: user?.fullName || '',
+      email: user?.primaryEmailAddress?.emailAddress || '',
       employee_code: '',
       job_title: '',
       department_id: '',
@@ -107,6 +107,21 @@ export default function ProfileForm({ departments, stages, roles, users }: Profi
       supervisor_id: '',
     },
   });
+
+  // Update form values when user data is loaded
+  useEffect(() => {
+    if (user) {
+      const fullName = user.firstName && user.lastName
+        ? `${user.lastName} ${user.firstName}`
+        : user.fullName || '';
+      
+      form.reset({
+        ...form.getValues(),
+        name: fullName,
+        email: user.primaryEmailAddress?.emailAddress || '',
+      });
+    }
+  }, [user, form]);
 
   // Get available users for supervisor selection (excluding current user if editing)
   const availableUsers = users;


### PR DESCRIPTION
### Summary
プロフィール入力フォームの「プロフィールを作成」ボタンが、必須フィールド（「名前」と「メールアドレス」）の不足により機能しないという問題に対処。
これらのフィールドが入力されず、Clerkから取得されるため、フォームの検証に失敗し、送信できない状態であった。

### Changes
- Populate the form’s `name` and `email` fields with the current user's data from Clerk as soon as it is available.
- Add read-only input fields for `name` and `email` to the form, ensuring these values are present for validation but not editable by the user.
- This resolves the validation issue and allows the profile creation process to complete as expected.

### Testing
- Verified that the form now initializes with the correct user data.
- Confirmed that the "Create profile" button is enabled and the profile can be created successfully.