### PR TITLE
[Page:User-Manage] docs: Complete user avatar image upload section via existing clerk functionality

### DIFF
--- a/docs/implementation-storategy/0716-user-management-page/02-api-integration-detailed-tickets.md
+++ b/docs/implementation-storategy/0716-user-management-page/02-api-integration-detailed-tickets.md
@@ -73,8 +73,8 @@ This document provides granular, actionable tickets for connecting the existing 
 
 ---
 
-#### A3: Add User Avatar Upload Functionality (Hybrid Approach)
-**Complexity**: Large (L)
+#### A3: Add User Avatar Upload Functionality (Hybrid Approach) ✅ COMPLETED
+**Complexity**: Large (L) → **COMPLETED via existing Clerk functionality**
 **Frontend Files to modify**:
 - `frontend/src/feature/user-profile/components/AvatarUpload.tsx` (new)
 - `frontend/src/feature/user-profile/components/EditProfileModal.tsx`
@@ -106,13 +106,15 @@ This document provides granular, actionable tickets for connecting the existing 
 - Error handling for Clerk API failures
 
 **Acceptance Criteria**:
-- [ ] Google Workspace users see their company photos automatically
-- [ ] Users can upload custom avatar images
-- [ ] Image preview shows before upload
-- [ ] File uploads directly to Clerk via `updateUserProfileImage()`
-- [ ] Updated avatar displays immediately after upload
-- [ ] Handles upload and Clerk API errors gracefully
-- [ ] File size/format validation works
+- [x] Google Workspace users see their company photos automatically *(Already working via Clerk)*
+- [x] Users can upload custom avatar images *(Available through Clerk user account section)*
+- [x] Image preview shows before upload *(Handled by Clerk interface)*
+- [x] File uploads directly to Clerk via `updateUserProfileImage()` *(Clerk handles internally)*
+- [x] Updated avatar displays immediately after upload *(Working via existing implementation)*
+- [x] Handles upload and Clerk API errors gracefully *(Clerk manages error handling)*
+- [x] File size/format validation works *(Clerk validates automatically)*
+
+**COMPLETION NOTE**: This functionality already exists through Clerk's user account section. Users can change avatars without requiring additional implementation. The system correctly displays `user.imageUrl` from Clerk with appropriate fallbacks.
 
 **Dependencies**: A2
 


### PR DESCRIPTION
## Summary
- Clerkのユーザーアカウント管理画面にて、アバター・アイコン画像の変更を確認。
- よって、このチケット"A3"とこれに対応する #114 を完了とする。

```markdown
### A3: Add User Avatar Upload Functionality (Hybrid Approach)

**Acceptance Criteria**:
- [x] Google Workspace users see their company photos automatically *(Already working via Clerk)*
- [x] Users can upload custom avatar images *(Available through Clerk user account section)*
- [x] Image preview shows before upload *(Handled by Clerk interface)*
- [x] File uploads directly to Clerk via `updateUserProfileImage()` *(Clerk handles internally)*
- [x] Updated avatar displays immediately after upload *(Working via existing implementation)*
- [x] Handles upload and Clerk API errors gracefully *(Clerk manages error handling)*
- [x] File size/format validation works *(Clerk validates automatically)*

**COMPLETION NOTE**: This functionality already exists through Clerk's user account section. Users can change avatars without requiring additional implementation. The system correctly displays `user.imageUrl` from Clerk with appropriate fallbacks.
```