### PR TITLE
refactor: Goal Update Types by Category, Adjust Repository Logic, and Simplify Approval Flow

### DIFF
--- a/backend/app/database/repositories/goal_repo.py
+++ b/backend/app/database/repositories/goal_repo.py
@@ -12,7 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..models.goal import Goal
 from ..models.user import User
 from ..models.evaluation import EvaluationPeriod
-from ...schemas.goal import GoalCreate, GoalUpdate, GoalStatus
+from ...schemas.goal import (
+    GoalCreate, GoalUpdate, GoalStatus,
+    PerformanceGoalUpdate, CompetencyGoalUpdate, CoreValueGoalUpdate
+)
 from ...schemas.common import PaginationParams
 from ...core.exceptions import (
     NotFoundError, ConflictError, ValidationError
@@ -308,25 +311,31 @@ class GoalRepository:
             # Build target_data for category-specific fields
             target_data_updates = {}
             
-            # Performance goal fields
-            if goal_data.performance_goal_type is not None:
-                target_data_updates["performance_goal_type"] = goal_data.performance_goal_type.value
-            if goal_data.specific_goal_text is not None:
-                target_data_updates["specific_goal_text"] = goal_data.specific_goal_text
-            if goal_data.achievement_criteria_text is not None:
-                target_data_updates["achievement_criteria_text"] = goal_data.achievement_criteria_text
-            if goal_data.means_methods_text is not None:
-                target_data_updates["means_methods_text"] = goal_data.means_methods_text
+            # Check the type of goal_data and handle accordingly
+            if isinstance(goal_data, PerformanceGoalUpdate):
+                # Performance goal fields
+                if goal_data.title is not None:
+                    target_data_updates["title"] = goal_data.title
+                if goal_data.performance_goal_type is not None:
+                    target_data_updates["performance_goal_type"] = goal_data.performance_goal_type.value
+                if goal_data.specific_goal_text is not None:
+                    target_data_updates["specific_goal_text"] = goal_data.specific_goal_text
+                if goal_data.achievement_criteria_text is not None:
+                    target_data_updates["achievement_criteria_text"] = goal_data.achievement_criteria_text
+                if goal_data.means_methods_text is not None:
+                    target_data_updates["means_methods_text"] = goal_data.means_methods_text
             
-            # Competency goal fields
-            if goal_data.competency_id is not None:
-                target_data_updates["competency_id"] = str(goal_data.competency_id)
-            if goal_data.action_plan is not None:
-                target_data_updates["action_plan"] = goal_data.action_plan
+            elif isinstance(goal_data, CompetencyGoalUpdate):
+                # Competency goal fields
+                if goal_data.competency_id is not None:
+                    target_data_updates["competency_id"] = str(goal_data.competency_id)
+                if goal_data.action_plan is not None:
+                    target_data_updates["action_plan"] = goal_data.action_plan
             
-            # Core value goal fields
-            if goal_data.core_value_plan is not None:
-                target_data_updates["core_value_plan"] = goal_data.core_value_plan
+            elif isinstance(goal_data, CoreValueGoalUpdate):
+                # Core value goal fields
+                if goal_data.core_value_plan is not None:
+                    target_data_updates["core_value_plan"] = goal_data.core_value_plan
             
             if target_data_updates:
                 # Get current goal to merge target_data

--- a/backend/app/database/repositories/goal_repo.py
+++ b/backend/app/database/repositories/goal_repo.py
@@ -431,8 +431,9 @@ class GoalRepository:
     def _validate_status_transition(self, current_status: str, new_status: str) -> None:
         """Validate that the status transition is allowed."""
         valid_transitions = {
-            "draft": ["pending_approval", "rejected"],
-            "pending_approval": ["approved", "rejected", "draft"],
+            "incomplete": ["draft", "pending_approval"],  # Incomplete goals can be moved to draft or submitted
+            "draft": ["pending_approval"],
+            "pending_approval": ["approved", "rejected"],
             "approved": [],  # Approved goals cannot be changed
             "rejected": ["draft", "pending_approval"]
         }

--- a/backend/app/schemas/goal.py
+++ b/backend/app/schemas/goal.py
@@ -90,6 +90,29 @@ class GoalCreate(BaseModel):
         return values
 
 
+class PerformanceGoalUpdate(BaseModel):
+    """Schema for updating performance goals only"""
+    weight: Optional[float] = Field(None, ge=0, le=100)
+    title: Optional[str] = Field(None, alias="title")
+    performance_goal_type: Optional[PerformanceGoalType] = Field(None, alias="performanceGoalType")
+    specific_goal_text: Optional[str] = Field(None, alias="specificGoalText")
+    achievement_criteria_text: Optional[str] = Field(None, alias="achievementCriteriaText")
+    means_methods_text: Optional[str] = Field(None, alias="meansMethodsText")
+
+
+class CompetencyGoalUpdate(BaseModel):
+    """Schema for updating competency goals only"""
+    weight: Optional[float] = Field(None, ge=0, le=100)
+    competency_id: Optional[UUID] = Field(None, alias="competencyId")
+    action_plan: Optional[str] = Field(None, alias="actionPlan")
+
+
+class CoreValueGoalUpdate(BaseModel):
+    """Schema for updating core value goals only"""
+    weight: Optional[float] = Field(None, ge=0, le=100)
+    core_value_plan: Optional[str] = Field(None, alias="coreValuePlan")
+
+
 class GoalUpdate(BaseModel):
     """Schema for updating a goal content via API (no status changes)"""
     weight: Optional[float] = Field(None, ge=0, le=100)

--- a/backend/app/schemas/goal.py
+++ b/backend/app/schemas/goal.py
@@ -113,22 +113,8 @@ class CoreValueGoalUpdate(BaseModel):
     core_value_plan: Optional[str] = Field(None, alias="coreValuePlan")
 
 
-class GoalUpdate(BaseModel):
-    """Schema for updating a goal content via API (no status changes)"""
-    weight: Optional[float] = Field(None, ge=0, le=100)
-    
-    # Performance Goal fields (goal_category = "業績目標")
-    performance_goal_type: Optional[PerformanceGoalType] = Field(None, alias="performanceGoalType")
-    specific_goal_text: Optional[str] = Field(None, alias="specificGoalText")
-    achievement_criteria_text: Optional[str] = Field(None, alias="achievementCriteriaText")
-    means_methods_text: Optional[str] = Field(None, alias="meansMethodsText")
-    
-    # Competency Goal fields (goal_category = "コンピテンシー")
-    competency_id: Optional[UUID] = Field(None, alias="competencyId")
-    action_plan: Optional[str] = Field(None, alias="actionPlan")
-    
-    # Core Value Goal fields (goal_category = "コアバリュー")
-    core_value_plan: Optional[str] = Field(None, alias="coreValuePlan")
+# Union type for goal updates based on category
+GoalUpdate = Union[PerformanceGoalUpdate, CompetencyGoalUpdate, CoreValueGoalUpdate]
 
 
 class GoalStatusUpdate(BaseModel):

--- a/backend/app/services/goal_service.py
+++ b/backend/app/services/goal_service.py
@@ -207,14 +207,6 @@ class GoalService:
             if not updated_goal:
                 raise NotFoundError(f"Goal with ID {goal_id} not found after update")
             
-            # Reset approval if substantial changes made
-            if self._requires_reapproval(goal_data):
-                await self.goal_repo.update_goal_status(
-                    goal_id, 
-                    GoalStatus.DRAFT if updated_goal.status == GoalStatus.APPROVED.value else GoalStatus(updated_goal.status)
-                )
-                updated_goal = await self.goal_repo.get_goal_by_id(goal_id)
-            
             # Commit transaction
             await self.session.commit()
             
@@ -573,20 +565,6 @@ class GoalService:
                 f"Total weight for {goal_category} would exceed 100%. "
                 f"Current: {current_total}%, Adding: {new_weight}%, Total: {new_total}%"
             )
-
-    def _requires_reapproval(self, goal_data: GoalUpdate) -> bool:
-        """Check if the update requires reapproval."""
-        # Any change to content fields requires reapproval
-        content_fields = [
-            'specific_goal_text', 'achievement_criteria_text', 'means_methods_text',
-            'action_plan', 'core_value_plan', 'weight'
-        ]
-        
-        for field in content_fields:
-            if getattr(goal_data, field, None) is not None:
-                return True
-        
-        return False
 
     async def _enrich_goal_data(self, goal_model: GoalModel) -> Goal:
         """Convert GoalModel to Goal response schema with enriched data."""

--- a/backend/app/services/goal_service.py
+++ b/backend/app/services/goal_service.py
@@ -13,7 +13,8 @@ from ..database.repositories.competency_repo import CompetencyRepository
 from ..database.repositories.supervisor_review_repository import SupervisorReviewRepository
 from ..database.models.goal import Goal as GoalModel
 from ..schemas.goal import (
-    GoalCreate, GoalUpdate, Goal, GoalDetail, GoalStatus
+    GoalCreate, GoalUpdate, Goal, GoalDetail, GoalStatus,
+    PerformanceGoalUpdate, CompetencyGoalUpdate, CoreValueGoalUpdate
 )
 from ..schemas.common import PaginationParams, PaginatedResponse
 from ..security.context import AuthContext
@@ -538,7 +539,7 @@ class GoalService:
     async def _validate_goal_update(self, goal_data: GoalUpdate, existing_goal: GoalModel):
         """Validate goal update business rules."""
         # Check if competency exists (for competency goals)
-        if goal_data.competency_id:
+        if isinstance(goal_data, CompetencyGoalUpdate) and goal_data.competency_id:
             competency = await self.competency_repo.get_by_id(goal_data.competency_id)
             if not competency:
                 raise BadRequestError(f"Competency {goal_data.competency_id} not found")


### PR DESCRIPTION
### Summary
- Split `GoalUpdate` into category-specific schemas: `PerformanceGoalUpdate`, `CompetencyGoalUpdate`, `CoreValueGoalUpdate`.
- Update repository logic to apply updates conditionally by goal category and allow performance goal title edits.
- Refine status transition rules to include `incomplete` and restrict transitions post-submission/approval.
- Remove auto "re-approval on content change" logic from service; leave status transitions to explicit status updates.

### Context/Motivation
- Mixed-field `GoalUpdate` made validation and partial updates ambiguous across goal categories.
- Product requirement: allow editing `title` for performance goals; ensure category-specific safety.
- Clarify business flow: content edits should not implicitly change approval state; approval/status updates are explicit user actions.

### Key Changes
- backend/app/schemas/goal.py
  - Introduced:
    - `PerformanceGoalUpdate` (adds optional `title`, plus performance fields)
    - `CompetencyGoalUpdate`
    - `CoreValueGoalUpdate`
  - Defined `GoalUpdate = Union[PerformanceGoalUpdate, CompetencyGoalUpdate, CoreValueGoalUpdate]`
- backend/app/database/repositories/goal_repo.py
  - `update_goal`: Branch by `isinstance` of `goal_data` to apply only relevant fields per category
  - Allow updating `title` when `PerformanceGoalUpdate` is used
  - Status transitions updated:
    - Added `incomplete` → `draft` | `pending_approval`
    - Removed ability to move `draft` → `rejected`, and `pending_approval` → `draft`
- backend/app/services/goal_service.py
  - Import new schemas
  - Validation respects category (`competency_id` check only for `CompetencyGoalUpdate`)
  - Removed `_requires_reapproval` and the implicit re-approval behavior
