### PR TITLE
feat: Implement Goal-Service's Server Action on Frontend

### DIFF
--- a/frontend/src/api/constants/config.ts
+++ b/frontend/src/api/constants/config.ts
@@ -110,8 +110,11 @@ export const API_ENDPOINTS = {
     CREATE: '/goals',
     UPDATE: (id: string) => `/goals/${id}`,
     DELETE: (id: string) => `/goals/${id}`,
-    BY_USER: (userId: string) => `/goals/user/${userId}`,
-    BY_PERIOD: (periodId: string) => `/goals/period/${periodId}`,
+    SUBMIT: (id: string) => `/goals/${id}/submit`,
+    APPROVE: (id: string) => `/goals/${id}/approve`,
+    REJECT: (id: string) => `/goals/${id}/reject`,
+    // BY_USER: (userId: string) => `/goals/user/${userId}`,
+    // BY_PERIOD: (periodId: string) => `/goals/period/${periodId}`,
   },
   
   // Goal Category endpoints

--- a/frontend/src/api/server-actions/goals.ts
+++ b/frontend/src/api/server-actions/goals.ts
@@ -1,0 +1,116 @@
+'use server';
+import { API_ENDPOINTS } from '../constants/config';
+import type { UUID } from '../types/common';
+import type {
+    GoalCreateRequest,
+    GoalUpdateRequest,
+    GoalListResponse,
+    GoalResponse,
+} from '../types/goal';
+import { getHttpClient } from '../client/http-client';
+
+
+// Get goals with filters - maps directly to GET /goals backend endpoint
+export async function getGoalsAction(params?: {
+    periodId?: UUID;
+    userId?: UUID;
+    goalCategory?: string;
+    status?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<{ success: boolean; data?: GoalListResponse; error?: string }> {
+    try {
+      const http = getHttpClient();
+      const query = new URLSearchParams();
+      
+      // Add all supported backend filters
+      if (params?.periodId) {
+        query.append('periodId', params.periodId);
+      }
+      if (params?.userId) {
+        query.append('userId', params.userId);
+      }
+      if (params?.goalCategory) {
+        query.append('goalCategory', params.goalCategory);
+      }
+      if (params?.status) {
+        query.append('status', params.status);
+      }
+      if (params?.page) {
+        query.append('page', String(params.page));
+      }
+      if (params?.limit) {
+        query.append('limit', String(params.limit));
+      }
+  
+      // Construct final endpoint
+      const endpoint = query.toString() 
+        ? `${API_ENDPOINTS.GOALS.LIST}?${query.toString()}`
+        : API_ENDPOINTS.GOALS.LIST;
+  
+      // Make the API call
+      const res = await http.get<GoalListResponse>(endpoint);
+      
+      if (!res.success || !res.data) {
+        return { success: false, error: res.errorMessage || 'Failed to fetch goals' };
+      }
+  
+      return { success: true, data: res.data };
+    } catch (e) {
+      const error = e instanceof Error ? e.message : 'Failed to fetch goals';
+      return { success: false, error };
+    }
+  }
+
+// Create a goal
+export async function createGoalAction(data: GoalCreateRequest): Promise<{
+success: boolean;
+data?: GoalResponse;
+error?: string;
+}> {
+try {
+    const http = getHttpClient();
+    const res = await http.post<GoalResponse>(API_ENDPOINTS.GOALS.CREATE, data);
+    if (!res.success || !res.data) {
+    return { success: false, error: res.errorMessage || 'Failed to create goal' };
+    }
+    return { success: true, data: res.data };
+} catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Failed to create goal' };
+}
+}
+
+// Update goal
+export async function updateGoalAction(id: UUID, data: GoalUpdateRequest): Promise<{
+success: boolean;
+data?: GoalResponse;
+error?: string;
+}> {
+try {
+    const http = getHttpClient();
+    const res = await http.put<GoalResponse>(API_ENDPOINTS.GOALS.UPDATE(id), data);
+    if (!res.success || !res.data) {
+    return { success: false, error: res.errorMessage || 'Failed to update goal' };
+    }
+    return { success: true, data: res.data };
+} catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Failed to update goal' };
+}
+}
+
+// Delete goal
+export async function deleteGoalAction(id: UUID): Promise<{
+success: boolean;
+error?: string;
+}> {
+try {
+    const http = getHttpClient();
+    const res = await http.delete(API_ENDPOINTS.GOALS.DELETE(id));
+    if (!res.success) {
+    return { success: false, error: res.errorMessage || 'Failed to delete goal' };
+    }
+    return { success: true };
+} catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Failed to delete goal' };
+}
+}

--- a/frontend/src/api/server-actions/goals.ts
+++ b/frontend/src/api/server-actions/goals.ts
@@ -114,3 +114,47 @@ try {
     return { success: false, error: e instanceof Error ? e.message : 'Failed to delete goal' };
 }
 }
+
+// Submit goal
+export async function submitGoalAction(id: UUID): Promise<{
+    success: boolean;
+    data?: GoalResponse;
+    error?: string;
+  }> {
+    try {
+      const http = getHttpClient();
+      const res = await http.post<GoalResponse>(API_ENDPOINTS.GOALS.SUBMIT(id));
+      if (!res.success || !res.data) {
+        return { success: false, error: res.errorMessage || 'Failed to submit goal' };
+      }
+      return { success: true, data: res.data };
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : 'Failed to submit goal' };
+    }
+  }
+
+// Supervisor: approve pending goal
+export async function approveGoalAction(goalId: UUID): Promise<{ success: boolean; data?: GoalResponse; error?: string }> {
+    try {
+      const http = getHttpClient();
+      const res = await http.post<GoalResponse>(API_ENDPOINTS.GOALS.APPROVE(goalId));
+      if (!res.success || !res.data) return { success: false, error: res.errorMessage || 'Failed to approve goal' };
+      return { success: true, data: res.data };
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : 'Failed to approve goal' };
+    }
+  }
+  
+  // Supervisor: reject pending goal
+  export async function rejectGoalAction(goalId: UUID, reason: string): Promise<{ success: boolean; data?: GoalResponse; error?: string }> {
+    try {
+      const http = getHttpClient();
+      const endpoint = `${API_ENDPOINTS.GOALS.REJECT(goalId)}?reason=${encodeURIComponent(reason)}`;
+      const res = await http.post<GoalResponse>(endpoint);
+      if (!res.success || !res.data) return { success: false, error: res.errorMessage || 'Failed to reject goal' };
+      return { success: true, data: res.data };
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : 'Failed to reject goal' };
+    }
+  }
+  

--- a/frontend/src/api/server-actions/index.ts
+++ b/frontend/src/api/server-actions/index.ts
@@ -1,3 +1,4 @@
 // Re-export all server actions
 export * from './users';
 export * from './auth';
+export * from './goals';

--- a/frontend/src/api/types/goal.ts
+++ b/frontend/src/api/types/goal.ts
@@ -1,0 +1,92 @@
+import { UUID, PaginatedResponse } from './common';
+
+export type GoalStatus = 'incomplete' | 'draft' | 'pending_approval' | 'approved' | 'rejected';
+export type PerformanceGoalType = 'quantitative' | 'qualitative';
+
+export interface GoalBase {
+  periodId: UUID;
+  goalCategory: string; // "業績目標" | "コンピテンシー" | "コアバリュー"
+  weight: number; // 0-100
+  status: GoalStatus;
+}
+
+// Performance goal specific fields
+export interface PerformanceGoalFields {
+  title: string;
+  performanceGoalType: PerformanceGoalType;
+  specificGoalText: string;
+  achievementCriteriaText: string;
+  meansMethodsText: string;
+}
+
+// Competency goal specific fields
+export interface CompetencyGoalFields {
+  competencyId: UUID;
+  actionPlan: string;
+}
+
+// Core value goal specific fields (not used in this flow but included for completeness)
+// export interface CoreValueGoalFields {
+//   coreValuePlan: string;
+// }
+
+export type GoalCreateRequest =
+  | (GoalBase & { goalCategory: '業績目標' } & PerformanceGoalFields)
+  | (GoalBase & { goalCategory: 'コンピテンシー' } & CompetencyGoalFields);
+//   | (GoalBase & { goalCategory: 'コアバリュー' } & CoreValueGoalFields);
+
+// Performance goal update fields - all optional since it's an update
+export interface PerformanceGoalUpdateFields {
+  title?: string;
+  performanceGoalType?: PerformanceGoalType;
+  specificGoalText?: string;
+  achievementCriteriaText?: string;
+  meansMethodsText?: string;
+}
+
+// Competency goal update fields - all optional since it's an update
+export interface CompetencyGoalUpdateFields {
+  competencyId?: UUID;
+  actionPlan?: string;
+}
+
+// // Core value goal update fields - all optional since it's an update
+//     export interface CoreValueGoalUpdateFields {
+//     coreValuePlan?: string;
+// }
+
+export type GoalUpdateRequest =
+  | ({ weight?: number } & PerformanceGoalUpdateFields)
+  | ({ weight?: number } & CompetencyGoalUpdateFields);
+//   | ({ weight?: number } & CoreValueGoalUpdateFields);
+
+export interface GoalResponse {
+  id: UUID;
+  userId: UUID;
+  periodId: UUID;
+  goalCategory: string;
+  weight: number;
+  status: GoalStatus;
+  approvedBy?: UUID | null;
+  approvedAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+
+  // Performance fields (when goalCategory is "業績目標")
+  title?: string;
+  performanceGoalType?: PerformanceGoalType;
+  specificGoalText?: string;
+  achievementCriteriaText?: string;
+  meansMethodsText?: string;
+
+  // Competency fields (when goalCategory is "コンピテンシー")
+  competencyId?: UUID;
+  actionPlan?: string;
+
+  // Core value fields (when goalCategory is "コアバリュー")
+//   coreValuePlan?: string;
+}
+
+export interface GoalListResponse extends PaginatedResponse<GoalResponse> {}
+
+

--- a/frontend/src/api/types/index.ts
+++ b/frontend/src/api/types/index.ts
@@ -7,6 +7,9 @@ export * from './auth';
 // User types
 export * from './user';
 
+// Goal types
+export * from './goal';
+
 // API Response wrapper type
 export interface ApiResponse<T = unknown> {
   success: boolean;


### PR DESCRIPTION
## Summary
- Goal関連のサーバーアクションの実装
- フロントエンドへのAPIエンドポイントの統合

## Related Issues
- #163 
- #164 
- #165 
- #167 

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- Added Goal TypeScript types and interfaces for performance and competency goals
- Implemented CRUD server actions for Goal management
- Added submit, approve, and reject workflow actions for goal status management
- Updated API endpoints configuration to include new goal action routes
- Re-exported goal server actions and types in index files for easy import

## Additional Notes
This PR implements the frontend side of goal management, providing server actions that map directly to backend API endpoints for managing goals with proper TypeScript type safety and Clerk authentication integration.