### PR TITLE
fix(user-service): remove obsolete stage_id validation in user update

### DIFF
--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -804,12 +804,6 @@ class UserService:
             if not department:
                 raise BadRequestError(f"Department with ID {user_data.department_id} does not exist")
         
-        # Validate stage exists if being updated
-        if user_data.stage_id is not None:
-            stage = await self.stage_repo.get_by_id(user_data.stage_id)
-            if not stage:
-                raise BadRequestError(f"Stage with ID {user_data.stage_id} does not exist")
-    
     
     async def _enrich_user_data(self, user: UserModel) -> User:
         """Enrich user data with relationships using repository pattern"""


### PR DESCRIPTION
## Summary
Fixed 500 error on `PUT /users/{user_id}` by removing obsolete `stage_id` validation from `_validate_user_update` method.

## Changes
- Removed stage_id validation code that referenced non-existent field in UserUpdate schema
- Stage updates now handled exclusively via dedicated admin endpoint `PATCH /users/{user_id}/stage`

Fixes AttributeError: 'UserUpdate' object has no attribute 'stage_id'