### PR TITLE
fix(ui): synchronize organization chart data with user updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ backend/tests/logs
 
 # VS Code settings (personal configurations)
 .vscode/
+
+# Kiro
+.kiro/local_kiro/

--- a/frontend/src/feature/user-profiles/display/OrganizationViewWithOrgChart.tsx
+++ b/frontend/src/feature/user-profiles/display/OrganizationViewWithOrgChart.tsx
@@ -14,9 +14,10 @@ interface OrganizationViewWithOrgChartProps {
   users: UserDetailResponse[];
   onUserUpdate?: (user: UserDetailResponse) => void;
   isFiltered?: boolean;
+  onEditModeChange?: (editMode: boolean) => void;
 }
 
-export default function OrganizationViewWithOrgChart({ users, onUserUpdate, isFiltered = false }: OrganizationViewWithOrgChartProps) {
+export default function OrganizationViewWithOrgChart({ users, onUserUpdate, isFiltered = false, onEditModeChange }: OrganizationViewWithOrgChartProps) {
   const [editMode, setEditMode] = useState(false);
   const [orgChartUsers, setOrgChartUsers] = useState<SimpleUser[] | null>(null);
   // Single source of truth for what the chart renders
@@ -63,7 +64,9 @@ export default function OrganizationViewWithOrgChart({ users, onUserUpdate, isFi
   }, [isFiltered, users]);
 
   const toggleEditMode = () => {
-    setEditMode(!editMode);
+    const newEditMode = !editMode;
+    setEditMode(newEditMode);
+    onEditModeChange?.(newEditMode);
   };
 
   const renderReadOnlyView = () => {

--- a/frontend/src/feature/user-profiles/display/UserManagementWithSearch.tsx
+++ b/frontend/src/feature/user-profiles/display/UserManagementWithSearch.tsx
@@ -132,16 +132,7 @@ export default function UserManagementWithSearch({ initialUsers }: UserManagemen
           </div>
         )}
 
-        {/* Empty state */}
-        {users.length === 0 && viewMode !== 'organization' && (
-          <div className="text-center py-8">
-            <AlertCircle className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
-            <h3 className="text-lg font-semibold text-muted-foreground">該当するユーザーが見つかりませんでした</h3>
-            <p className="text-sm text-muted-foreground mt-2">
-              検索条件を変更してもう一度お試しください。
-            </p>
-          </div>
-        )}
+        {/* Empty state is handled within each view component to avoid duplication */}
 
         {/* Current view */}
         {renderCurrentView()}

--- a/frontend/src/feature/user-profiles/display/UserManagementWithSearch.tsx
+++ b/frontend/src/feature/user-profiles/display/UserManagementWithSearch.tsx
@@ -25,7 +25,7 @@ export default function UserManagementWithSearch({ initialUsers }: UserManagemen
   const [orgUsers, setOrgUsers] = useState<UserDetailResponse[]>(initialUsers);
   const [orgIsFiltered, setOrgIsFiltered] = useState<boolean>(false);
   // Track edit mode for organization view
-  const [isEditMode, setIsEditMode] = useState<boolean>(false);
+  const [isOrganizationEditMode, setIsOrganizationEditMode] = useState<boolean>(false);
 
   const { viewMode, setViewMode } = useViewMode('table');
 
@@ -54,7 +54,7 @@ export default function UserManagementWithSearch({ initialUsers }: UserManagemen
 
   // Callback to handle edit mode changes from OrganizationViewWithOrgChart
   const handleEditModeChange = (editMode: boolean) => {
-    setIsEditMode(editMode);
+    setIsOrganizationEditMode(editMode);
   };
 
   // Callback to handle search results from UserSearch component
@@ -62,7 +62,7 @@ export default function UserManagementWithSearch({ initialUsers }: UserManagemen
     setError(null);
     if (viewMode === 'organization') {
       // Apply security restriction only in edit mode for non-admin users
-      if (isEditMode && initialUsers.length === 1) {
+      if (isOrganizationEditMode && initialUsers.length === 1) {
         // Employee heuristic: initialUsers length == 1 → restrict to self only in edit mode
         setOrgUsers(initialUsers);
         setOrgIsFiltered(false);

--- a/frontend/src/feature/user-profiles/display/UserManagementWithSearch.tsx
+++ b/frontend/src/feature/user-profiles/display/UserManagementWithSearch.tsx
@@ -22,7 +22,7 @@ export default function UserManagementWithSearch({ initialUsers }: UserManagemen
   const [error, setError] = useState<string | null>(null);
   const [isFiltered, setIsFiltered] = useState<boolean>(false);
   // Keep Organization Chart dataset isolated so filters there don't affect Table/Gallery
-  const [orgUsers, setOrgUsers] = useState<UserDetailResponse[]>([]);
+  const [orgUsers, setOrgUsers] = useState<UserDetailResponse[]>(initialUsers);
   const [orgIsFiltered, setOrgIsFiltered] = useState<boolean>(false);
 
   const { viewMode, setViewMode } = useViewMode('table');
@@ -31,6 +31,7 @@ export default function UserManagementWithSearch({ initialUsers }: UserManagemen
   useEffect(() => {
     if (initialUsers.length > 0) {
       setUsers(initialUsers);
+      setOrgUsers(initialUsers);
       setTotalUsers(initialUsers.length);
     }
   }, [initialUsers]);
@@ -39,6 +40,11 @@ export default function UserManagementWithSearch({ initialUsers }: UserManagemen
   const handleUserUpdate = (updatedUser: UserDetailResponse) => {
     setUsers(prevUsers => 
       prevUsers.map(user => 
+        user.id === updatedUser.id ? updatedUser : user
+      )
+    );
+    setOrgUsers(prevOrgUsers => 
+      prevOrgUsers.map(user => 
         user.id === updatedUser.id ? updatedUser : user
       )
     );


### PR DESCRIPTION
# 📄 Pull Request Summary - Branch 207

## 📝 Summary

Fix security vulnerability in organization hierarchy management where non-admin users could bypass role restrictions through search functionality in edit mode. Implementation applies the existing "employee heuristic" (`initialUsers.length === 1`) to organization view edit mode while preserving full functionality for readonly mode.

---

## 🔗 Related Issues

- Closes #207 - Organization editable chart disabled for admin role

---

## 🔀 Type of Change

Marque com um "x" o(s) tipo(s) de mudança(s) incluídas neste PR:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test coverage improvement

---

## 🔧 Changes Made

**Security Fix:**
- Added `onEditModeChange` prop to `OrganizationViewWithOrgChart` to communicate edit mode state to parent
- Implemented `isOrganizationEditMode` state tracking in `UserManagementWithSearch`
- Applied security restriction logic: `if (isOrganizationEditMode && initialUsers.length === 1)` to block search for non-admin users in edit mode
- Enhanced data synchronization between organization chart and user updates (from previous commit)

**Code Quality Improvements:**
- Renamed `isEditMode` to `isOrganizationEditMode` for better clarity and context specificity
- Improved variable naming following Clean Code conventions

---

## ✅ Testing Checklist

Marque os itens testados e validados antes de abrir este PR:

- [x] Feature funciona como esperado no ambiente de desenvolvimento
- [x] Funciona corretamente em diferentes navegadores (se aplicável ao frontend)
- [ ] Endpoints da API respondem corretamente (se aplicável ao backend)
- [ ] Operações no banco de dados funcionam como esperado
- [x] Tratamento de erros implementado corretamente

---

## 🗒️ Additional Notes

**Security Implementation:**
- **Admin users**: Can search and edit all users in edit mode (unchanged behavior)
- **Non-admin users**: Restricted to viewing only themselves in edit mode, but can view full hierarchy in readonly mode
- **Table/Gallery views**: Maintain existing secure behavior (already implemented employee heuristic)

**Design Decisions:**
- Reused existing `initialUsers.length === 1` heuristic instead of creating new role detection logic
- Applied restriction only to edit mode, preserving readonly functionality for all users
- Minimal code changes to reduce risk of regressions

**Backward Compatibility:**
- Zero breaking changes - all existing functionality preserved
- Admin users experience no change in behavior
- Non-admin users maintain full readonly access to organization hierarchy

**Future Improvements (optional):**
- Consider extracting role detection logic to utility functions for better testability
- Add unit tests for security restrictions
- Implement more granular role-based permissions

