### PR TITLE
refactor(users): extract stage update endpoint to constants

### DIFF
--- a/frontend/src/api/constants/config.ts
+++ b/frontend/src/api/constants/config.ts
@@ -61,6 +61,7 @@ export const API_ENDPOINTS = {
     BY_ID: (id: string) => `/users/${id}`,
     CREATE: '/users',
     UPDATE: (id: string) => `/users/${id}`,
+    UPDATE_STAGE: (id: string) => `/users/${id}/stage`,
     DELETE: (id: string) => `/users/${id}`,
     EXISTS: (clerkId: string) => `/users/exists/${clerkId}`,
     PROFILE_OPTIONS: '/users/profile-options',

--- a/frontend/src/api/endpoints/users.ts
+++ b/frontend/src/api/endpoints/users.ts
@@ -79,7 +79,7 @@ export const usersApi = {
    * Update user's stage (admin only)
    */
   updateUserStage: async (userId: UUID, data: { stage_id: UUID }): Promise<ApiResponse<UserDetailResponse>> => {
-    return httpClient.patch<UserDetailResponse>(`${API_ENDPOINTS.USERS.BY_ID(userId)}/stage`, data);
+    return httpClient.patch<UserDetailResponse>(API_ENDPOINTS.USERS.UPDATE_STAGE(userId), data);
   },
 
   /**


### PR DESCRIPTION
## Summary
- Extract user stage update endpoint to `API_ENDPOINTS.USERS.UPDATE_STAGE` constant
- Replace inline string concatenation with centralized endpoint definition
- Additional Update from #196 

## Changes
- Add `UPDATE_STAGE` endpoint constant in `config.ts`
- Update `usersApi.updateUserStage` to use the new constant