### PR TITLE
Fix: add missing List type import for improved type annotations

### DIFF
--- a/backend/app/services/evaluation_period_service.py
+++ b/backend/app/services/evaluation_period_service.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Optional, List
 from uuid import UUID
 from datetime import date
 


### PR DESCRIPTION
## Summary
- The backend service was failing to start due to a Python import error in the evaluation_period_service.py file
- Related PR: #245