### PR TITLE
fix: restore safe RBAC default for admin goal access (Issue #398)

### DIFF
--- a/backend/app/services/goal_service.py
+++ b/backend/app/services/goal_service.py
@@ -906,12 +906,14 @@ class GoalService:
         requested_user_id: Optional[UUID] = None
     ) -> Optional[List[UUID]]:
         """Determine which users' goals the current user can access."""
-        
+
         if current_user_context.has_permission(Permission.GOAL_READ_ALL):
-            # Admin: full visibility. Respect explicit user filter; otherwise no user filter.
+            # Admin: can read any user's goals when explicitly requested
             if requested_user_id:
                 return [requested_user_id]
-            return None
+            # Safe default: admin sees only their own goals unless explicitly requesting others
+            # For org-wide view, use get_all_goals_for_admin() endpoint instead
+            return [current_user_context.user_id]
         
         accessible_ids = []
         


### PR DESCRIPTION
## 🔧 Summary

This PR fixes a critical bug where admin users were blocked from creating their own goals due to incorrect RBAC default behavior.

## 📋 Problem

**Issue**: [#398](https://github.com/shintairiku/evaluation-system/issues/398)

Admin users received error "新しい目標を作成できません。目標は既に提出されています" when trying to create goals, even when they had no goals in the selected period.

### Root Cause

The RBAC logic in `backend/app/services/goal_service.py` was changed in commit `2167d552` (Dec 2, 2025):

**Broken behavior**:
```python
if current_user_context.has_permission(Permission.GOAL_READ_ALL):
    if requested_user_id:
        return [requested_user_id]
    return None  # ❌ Returns ALL users' goals
```

**Impact**: When admin accessed goal-input without explicitly passing `userId`, backend returned goals from ALL users in the organization, causing validation to fail if ANY other user had submitted/approved goals.

## ✅ Solution

Restored the safe RBAC default behavior:

```python
if current_user_context.has_permission(Permission.GOAL_READ_ALL):
    if requested_user_id:
        return [requested_user_id]
    # Safe default: admin sees only their own goals unless explicitly requesting others
    return [current_user_context.user_id]  # ✅ Returns only admin's own goals
```

### Key Changes

**File**: `backend/app/services/goal_service.py` (line 910-916)

- Implements "principle of least privilege" - even admins see only their own data by default
- Admin can still view specific users' goals by passing `userId` parameter  
- Organization-wide dashboard continues to work via `get_all_goals_for_admin()` endpoint

## 🎯 Design Decision

The fix maintains two separate paths:

1. **`get_goals()`** - Personal operations (create, edit, list own goals)
   - Uses RBAC with safe default
   - Returns only accessible user_ids

2. **`get_all_goals_for_admin()`** - Admin dashboard (organization-wide view)
   - Bypasses RBAC filtering  
   - Returns all goals in organization

This ensures:
- ✅ Admins can create/manage their own goals normally
- ✅ Admin dashboard shows organization-wide data
- ✅ Better security (principle of least privilege)
- ✅ No performance issues

## 🧪 Testing

**To verify the fix**:

1. **Admin user can create goals**:
   - Login as ADMIN
   - Navigate to goal-input page
   - Select evaluation period
   - ✅ Should NOT show error "目標は既に提出されています"
   - ✅ Should allow creating goals normally

2. **Admin dashboard still works**:
   - Navigate to admin-users-goals page
   - ✅ Should see goals from ALL users

3. **No regression**:
   - Test EMPLOYEE and SUPERVISOR roles
   - ✅ Should work as before

## 📝 Timeline

- **Oct 28, 2025**: Original safe implementation
- **Dec 2, 2025**: RBAC behavior changed (commit `2167d552`)
- **Dec 10, 2025**: Fix implemented to restore safe default

## 🔗 Related

- **Issue**: #398
- **PR #394**: RBAC performance optimizations (does NOT conflict)
- **Breaking commit**: `2167d552` (Dec 2, 2025)

## ⚠️ Breaking Changes

None. This restores the original behavior that existed from Oct 28 - Dec 1, 2025.

---

**Status**: ✅ Ready for review and testing