### PR TITLE
fix: add assessment:read:self permission to supervisor role

### DIFF
--- a/backend/app/database/migrations/production/010_create_permissions_tables.sql
+++ b/backend/app/database/migrations/production/010_create_permissions_tables.sql
@@ -161,6 +161,7 @@ JOIN permissions p ON p.code IN (
     'evaluation:review',
     'competency:read:self',
     'assessment:read:subordinates',
+    'assessment:read:self',
     'assessment:manage:self',
     'report:access',
     'stage:read:all',

--- a/backend/app/database/migrations/production/027_add_assessment_read_self_to_supervisor.sql
+++ b/backend/app/database/migrations/production/027_add_assessment_read_self_to_supervisor.sql
@@ -1,0 +1,11 @@
+-- Migration: Add assessment:read:self permission to supervisor role
+-- Fix: Supervisors with only the supervisor role cannot access their own
+-- core-value evaluations or peer reviews because the role was missing
+-- the assessment:read:self permission.
+
+INSERT INTO role_permissions (organization_id, role_id, permission_id)
+SELECT r.organization_id, r.id, p.id
+FROM roles r
+JOIN permissions p ON p.code = 'assessment:read:self'
+WHERE r.name = 'supervisor'
+ON CONFLICT DO NOTHING;

--- a/backend/app/services/org_bootstrap_service.py
+++ b/backend/app/services/org_bootstrap_service.py
@@ -130,6 +130,7 @@ class OrgBootstrapService:
                 PermissionEnum.EVALUATION_READ,
                 PermissionEnum.EVALUATION_REVIEW,
                 PermissionEnum.ASSESSMENT_READ_SUBORDINATES,
+                PermissionEnum.ASSESSMENT_READ_SELF,
             ]
         )
 


### PR DESCRIPTION
## Summary
- Supervisors with only the "supervisor" role could not access core-value evaluations (appeared opaque/disabled) or peer reviews (empty state)
- Root cause: supervisor role was missing `assessment:read:self` permission, causing backend to return 403 silently
- Affected 6 users: 小倉 武史, 木村 透, 木野 裕也, 萩山 達成, 門垣 祐平, Arino Ran (pure supervisors without admin/eval_admin roles)

## Changes
- Added `assessment:read:self` to supervisor role in seed migration (`010_create_permissions_tables.sql`)
- Added `ASSESSMENT_READ_SELF` to supervisor bootstrap (`org_bootstrap_service.py`)
- New migration `027_add_assessment_read_self_to_supervisor.sql` to backfill existing orgs

## Test plan
- [x] Verified via direct service call that `CoreValueService.get_my_evaluation()` returns data for supervisor-only user
- [x] Verified `PeerReviewService.get_my_pending_reviews()` returns reviews for supervisor-only user
- [x] Confirmed no unintended access: `assessment:read:self` only grants access to own data
- [ ] Run migration `027` on staging/production
- [ ] Verify affected users can fill core-value and see peer reviews in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)