### PR TITLE
fix: add assessment:read:self permission to supervisor role

### DIFF
--- a/backend/app/database/migrations/production/010_create_permissions_tables.sql
+++ b/backend/app/database/migrations/production/010_create_permissions_tables.sql
@@ -161,6 +161,7 @@ JOIN permissions p ON p.code IN (
     'evaluation:review',
     'competency:read:self',
     'assessment:read:subordinates',
+    'assessment:read:self',
     'assessment:manage:self',
     'report:access',
     'stage:read:all',

--- a/backend/app/database/migrations/production/027_add_assessment_read_self_to_supervisor.sql
+++ b/backend/app/database/migrations/production/027_add_assessment_read_self_to_supervisor.sql
@@ -1,0 +1,11 @@
+-- Migration: Add assessment:read:self permission to supervisor role
+-- Fix: Supervisors with only the supervisor role cannot access their own
+-- core-value evaluations or peer reviews because the role was missing
+-- the assessment:read:self permission.
+
+INSERT INTO role_permissions (organization_id, role_id, permission_id)
+SELECT r.organization_id, r.id, p.id
+FROM roles r
+JOIN permissions p ON p.code = 'assessment:read:self'
+WHERE r.name = 'supervisor'
+ON CONFLICT DO NOTHING;

--- a/backend/app/services/org_bootstrap_service.py
+++ b/backend/app/services/org_bootstrap_service.py
@@ -130,6 +130,7 @@ class OrgBootstrapService:
                 PermissionEnum.EVALUATION_READ,
                 PermissionEnum.EVALUATION_REVIEW,
                 PermissionEnum.ASSESSMENT_READ_SUBORDINATES,
+                PermissionEnum.ASSESSMENT_READ_SELF,
             ]
         )
 


### PR DESCRIPTION
## Summary
Cherry-pick of #511 (already merged to develop) for production deployment.

- Supervisors with only the "supervisor" role could not access core-value evaluations or peer reviews
- Root cause: missing `assessment:read:self` permission on supervisor role (backend returned 403 silently)
- Adds the permission to seed, bootstrap, and a backfill migration for existing orgs

## Post-merge
Run migration `027_add_assessment_read_self_to_supervisor.sql` on production database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)