### PR TITLE
fix: preserve line breaks and set h-[200px] in evaluation-feedback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ uvicorn app.main:app --reload
   - `/app/database` - Database models and repositories
   - `/app/services` - Business logic
 - `/docs` - Documentation files
+  - `人事評価システム_ロジック仕様書_202603.md` - **Comprehensive evaluation logic specification**. This is the authoritative reference for all evaluation calculation rules: score mappings, rating scales, MBO/competency/core-value formulas, comprehensive evaluation logic, D-rule (forced demotion), level increase/decrease rules, and part-time employee handling. Always consult this document before modifying any evaluation calculation logic.
 
 ## Key Conventions
 - Use TypeScript for frontend code

--- a/frontend/src/feature/evaluation/shared/core-value/CoreValueCommentSection.tsx
+++ b/frontend/src/feature/evaluation/shared/core-value/CoreValueCommentSection.tsx
@@ -51,7 +51,7 @@ export function CoreValueCommentSection({
         onChange={(e) => onCommentChange(e.target.value)}
         onBlur={onCommentBlur}
         placeholder={placeholder}
-        className={`mt-1 text-sm rounded-md border-gray-300 focus:ring-2 ${focusRingColor} min-h-[100px]`}
+        className={`mt-1 text-sm rounded-md border-gray-300 focus:ring-2 ${focusRingColor} h-[200px]`}
         maxLength={maxLength}
         disabled={!isEditable}
       />

--- a/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/CompetencySelfAssessment.tsx
+++ b/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/CompetencySelfAssessment.tsx
@@ -369,7 +369,7 @@ export default function CompetencySelfAssessment({
                     <Label className="text-sm font-semibold text-gray-700 mb-2 block">
                       自己評価コメント
                     </Label>
-                    <div className="mt-1 text-sm text-gray-700 bg-white rounded-md border border-gray-300 p-3 max-h-[200px] overflow-y-auto whitespace-pre-wrap">
+                    <div className="mt-1 text-sm text-gray-700 bg-white rounded-md border border-gray-300 p-3 h-[200px] overflow-y-auto whitespace-pre-wrap">
                       {competencies[0]?.comment || <span className="text-gray-400">コメントなし</span>}
                     </div>
                     <div className="flex justify-start items-center mt-1">

--- a/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/CompetencySelfAssessment.tsx
+++ b/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/CompetencySelfAssessment.tsx
@@ -330,7 +330,7 @@ export default function CompetencySelfAssessment({
                         {competency.items.map((item) => (
                           <div key={item.id} className="bg-white rounded-lg p-4 border border-gray-200 min-h-[90px]">
                             <div className="flex flex-col gap-2">
-                              <p className="text-sm text-gray-700 break-words overflow-hidden">{item.description}</p>
+                              <p className="text-sm text-gray-700 break-words overflow-hidden whitespace-pre-wrap">{item.description}</p>
 
                               {/* Rating Display - Read only with visual feedback */}
                               <div className="flex items-center gap-3 flex-wrap">
@@ -369,7 +369,7 @@ export default function CompetencySelfAssessment({
                     <Label className="text-sm font-semibold text-gray-700 mb-2 block">
                       自己評価コメント
                     </Label>
-                    <div className="mt-1 text-sm text-gray-700 bg-white rounded-md border border-gray-300 p-3 h-[100px] overflow-y-auto">
+                    <div className="mt-1 text-sm text-gray-700 bg-white rounded-md border border-gray-300 p-3 max-h-[200px] overflow-y-auto whitespace-pre-wrap">
                       {competencies[0]?.comment || <span className="text-gray-400">コメントなし</span>}
                     </div>
                     <div className="flex justify-start items-center mt-1">

--- a/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/CompetencySupervisorEvaluation.tsx
+++ b/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/CompetencySupervisorEvaluation.tsx
@@ -260,7 +260,7 @@ function CompetencyItemCard({
         {items.map((item) => (
           <div key={item.id} className="bg-white rounded-lg p-4 border border-gray-200 min-h-[90px]">
             <div className="flex flex-col gap-2">
-              <p className="text-sm text-gray-700 break-words overflow-hidden">{item.description}</p>
+              <p className="text-sm text-gray-700 break-words overflow-hidden whitespace-pre-wrap">{item.description}</p>
 
               {/* Rating Selector */}
               <div className="flex items-center gap-3 flex-wrap">

--- a/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/CompetencySupervisorEvaluation.tsx
+++ b/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/CompetencySupervisorEvaluation.tsx
@@ -372,7 +372,7 @@ function CompetencyGoalGroup({
           onChange={(e) => handleCommentChange(e.target.value)}
           onBlur={handleCommentBlur}
           placeholder="上長としてのフィードバックを記入してください..."
-          className="mt-1 text-sm rounded-md border-gray-300 focus:ring-2 focus:ring-green-200 min-h-[100px]"
+          className="mt-1 text-sm rounded-md border-gray-300 focus:ring-2 focus:ring-green-200 h-[200px]"
           maxLength={5000}
           disabled={!isEditable}
         />

--- a/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/CoreValueSelfAssessment.tsx
+++ b/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/CoreValueSelfAssessment.tsx
@@ -133,7 +133,7 @@ export default function CoreValueSelfAssessment({
                 <Label className="text-sm font-semibold text-gray-700 mb-2 block">
                   自己評価コメント
                 </Label>
-                <div className="mt-1 text-sm text-gray-700 bg-white rounded-md border border-gray-300 p-3 max-h-[200px] overflow-y-auto whitespace-pre-wrap">
+                <div className="mt-1 text-sm text-gray-700 bg-white rounded-md border border-gray-300 p-3 h-[200px] overflow-y-auto whitespace-pre-wrap">
                   {comment.trim() || <span className="text-gray-400">コメントなし</span>}
                 </div>
                 <div className="flex justify-start items-center mt-1">

--- a/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/CoreValueSelfAssessment.tsx
+++ b/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/CoreValueSelfAssessment.tsx
@@ -133,7 +133,7 @@ export default function CoreValueSelfAssessment({
                 <Label className="text-sm font-semibold text-gray-700 mb-2 block">
                   自己評価コメント
                 </Label>
-                <div className="mt-1 text-sm text-gray-700 bg-white rounded-md border border-gray-300 p-3 h-[100px] overflow-y-auto">
+                <div className="mt-1 text-sm text-gray-700 bg-white rounded-md border border-gray-300 p-3 max-h-[200px] overflow-y-auto whitespace-pre-wrap">
                   {comment.trim() || <span className="text-gray-400">コメントなし</span>}
                 </div>
                 <div className="flex justify-start items-center mt-1">

--- a/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/PerformanceGoalsSelfAssessment.tsx
+++ b/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/PerformanceGoalsSelfAssessment.tsx
@@ -192,7 +192,7 @@ export default function PerformanceGoalsSelfAssessment({
               <Label className="text-sm font-semibold text-gray-700 mb-2 block">
                 自己評価コメント
               </Label>
-              <div className="mt-1 text-sm text-gray-700 bg-white rounded-md border border-gray-300 p-3 max-h-[200px] overflow-y-auto whitespace-pre-wrap">
+              <div className="mt-1 text-sm text-gray-700 bg-white rounded-md border border-gray-300 p-3 h-[200px] overflow-y-auto whitespace-pre-wrap">
                 {evalItem.comment || <span className="text-gray-400">コメントなし</span>}
               </div>
               <div className="flex justify-start items-center mt-1">

--- a/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/PerformanceGoalsSelfAssessment.tsx
+++ b/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/PerformanceGoalsSelfAssessment.tsx
@@ -129,7 +129,7 @@ export default function PerformanceGoalsSelfAssessment({
           >
             {/* Goal Header */}
             <div className="flex items-center gap-3 mb-2">
-              <div className="text-xl font-bold text-blue-800 flex-1 break-words overflow-hidden">{evalItem.specificGoal}</div>
+              <div className="text-xl font-bold text-blue-800 flex-1 break-words overflow-hidden whitespace-pre-wrap">{evalItem.specificGoal}</div>
               <Badge className="bg-blue-600 text-white text-sm px-3 py-1">
                 ウエイト {evalItem.weight}%
               </Badge>
@@ -192,7 +192,7 @@ export default function PerformanceGoalsSelfAssessment({
               <Label className="text-sm font-semibold text-gray-700 mb-2 block">
                 自己評価コメント
               </Label>
-              <div className="mt-1 text-sm text-gray-700 bg-white rounded-md border border-gray-300 p-3 h-[100px] overflow-y-auto">
+              <div className="mt-1 text-sm text-gray-700 bg-white rounded-md border border-gray-300 p-3 max-h-[200px] overflow-y-auto whitespace-pre-wrap">
                 {evalItem.comment || <span className="text-gray-400">コメントなし</span>}
               </div>
               <div className="flex justify-start items-center mt-1">

--- a/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/PerformanceGoalsSupervisorEvaluation.tsx
+++ b/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/PerformanceGoalsSupervisorEvaluation.tsx
@@ -198,7 +198,7 @@ function PerformanceGoalSupervisorCard({
     <div className="bg-green-50 border border-green-200 rounded-2xl shadow-sm px-6 py-5 space-y-5">
       {/* Goal Header */}
       <div className="flex items-center gap-3 mb-2">
-        <div className="text-xl font-bold text-green-800 flex-1 break-words overflow-hidden">{goal.specificGoal}</div>
+        <div className="text-xl font-bold text-green-800 flex-1 break-words overflow-hidden whitespace-pre-wrap">{goal.specificGoal}</div>
         <Badge className="bg-green-600 text-white text-sm px-3 py-1">
           ウエイト {goal.weight}%
         </Badge>

--- a/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/PerformanceGoalsSupervisorEvaluation.tsx
+++ b/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/PerformanceGoalsSupervisorEvaluation.tsx
@@ -283,7 +283,7 @@ function PerformanceGoalSupervisorCard({
           onChange={(e) => handleCommentChange(e.target.value)}
           onBlur={handleCommentBlur}
           placeholder="上長としてのフィードバックを記入してください..."
-          className="mt-1 text-sm rounded-md border-gray-300 focus:ring-2 focus:ring-green-200 min-h-[100px]"
+          className="mt-1 text-sm rounded-md border-gray-300 focus:ring-2 focus:ring-green-200 h-[200px]"
           maxLength={5000}
           disabled={!isEditable}
         />


### PR DESCRIPTION
## Summary
Cherry-pick of #513 (already merged to develop) for production deployment.

- 上長の評価フィードバック画面でテキストの改行が反映されず団子状態で表示されていた
- コメント枠が h-[100px] 固定で小さく内容の読解が困難だった
- `whitespace-pre-wrap` 追加 + コメント枠を `h-[200px]` 固定に変更（subordinate + supervisor）
- CLAUDE.md にロジック仕様書への参照を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)