### PR TITLE
fix: use MBO 0-100 scale for 業績目標 overall rating preview

### DIFF
--- a/frontend/src/feature/evaluation/employee/evaluation-input/display/PerformanceGoalsEvaluate.tsx
+++ b/frontend/src/feature/evaluation/employee/evaluation-input/display/PerformanceGoalsEvaluate.tsx
@@ -19,7 +19,7 @@ import {
   QUANTITATIVE_RATING_CODES,
   QUALITATIVE_RATING_CODES,
 } from "@/api/types/common";
-import { calculateWeightedRatingAverage, scoreToFinalRating } from "@/utils/rating";
+import { calculateMboOverallRating } from "@/utils/rating";
 import { useSelfAssessmentAutoSave } from "../hooks/useSelfAssessmentAutoSave";
 import { SaveStatusIndicator } from "@/feature/evaluation/shared/SaveStatusIndicator";
 import { SupervisorFeedbackAlert } from "./components";
@@ -220,10 +220,8 @@ export default function PerformanceGoalsEvaluate({
       weight: item.goal.weight || 0,
     }));
 
-    const avg = calculateWeightedRatingAverage(items);
-    if (avg === null) return null;
-
-    return scoreToFinalRating(avg);
+    const result = calculateMboOverallRating(items);
+    return result === '−' ? null : result;
   };
 
   const overallRating = calculateOverallRating();

--- a/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/PerformanceGoalsSelfAssessment.tsx
+++ b/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/PerformanceGoalsSelfAssessment.tsx
@@ -6,7 +6,7 @@ import { TrendingUp, ChevronDown, ChevronUp, Loader2 } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import type { GoalResponse, SelfAssessment as APISelfAssessment, RatingCode } from "@/api/types";
-import { calculateWeightedAverageRatingCode } from "@/utils/rating";
+import { calculateMboOverallRating } from "@/utils/rating";
 
 // Display data structure for a performance goal with its self-assessment
 export interface PerformanceGoalDisplayData {
@@ -51,9 +51,9 @@ export function transformPerformanceGoalsForDisplay(
     });
 }
 
-// Calculate overall rating based on weighted average (8-level scale)
+// Calculate overall rating using the MBO formula (spec sections 4-2, 4-3, 4-4)
 export function calculatePerformanceOverallRating(goals: PerformanceGoalDisplayData[]): string {
-  return calculateWeightedAverageRatingCode(
+  return calculateMboOverallRating(
     goals.map(goal => ({ rating: goal.ratingCode, weight: goal.weight }))
   );
 }

--- a/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/PerformanceGoalsSupervisorEvaluation.test.ts
+++ b/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/PerformanceGoalsSupervisorEvaluation.test.ts
@@ -26,26 +26,86 @@ function buildGoal(
   };
 }
 
-describe("calculateSupervisorOverallRating", () => {
-  it("uses supervisorRatingCode when both code and numeric score exist", () => {
+describe("calculateSupervisorOverallRating (MBO formula, spec 4-2/4-3/4-4)", () => {
+  it("returns SS for 定量 SS @ 80 + 定性 A @ 20 (92 pts ≥ 86)", () => {
+    // Regression test for reported bug: 西松大輝 case
     const result = calculateSupervisorOverallRating([
-      buildGoal({
-        supervisorRatingCode: "D",
-        supervisorRating: 6,
-      }),
+      buildGoal({ id: "g1", type: "quantitative", weight: 80, supervisorRatingCode: "SS" }),
+      buildGoal({ id: "g2", type: "qualitative", weight: 20, supervisorRatingCode: "A" }),
+    ]);
+
+    expect(result).toBe("SS");
+  });
+
+  it("returns SS when all goals are SS (100 pts)", () => {
+    const result = calculateSupervisorOverallRating([
+      buildGoal({ id: "g1", weight: 70, supervisorRatingCode: "SS" }),
+      buildGoal({ id: "g2", weight: 30, supervisorRatingCode: "SS" }),
+    ]);
+
+    expect(result).toBe("SS");
+  });
+
+  it("returns D when all goals are D (0 pts)", () => {
+    const result = calculateSupervisorOverallRating([
+      buildGoal({ id: "g1", weight: 80, supervisorRatingCode: "D" }),
+      buildGoal({ id: "g2", weight: 20, supervisorRatingCode: "D" }),
     ]);
 
     expect(result).toBe("D");
   });
 
-  it("falls back to numeric score when rating code is missing", () => {
+  it("returns S for SS @ 80 + C @ 20 (84 pts, just below SS threshold of 86)", () => {
     const result = calculateSupervisorOverallRating([
-      buildGoal({
-        supervisorRatingCode: undefined,
-        supervisorRating: 6,
-      }),
+      buildGoal({ id: "g1", weight: 80, supervisorRatingCode: "SS" }),
+      buildGoal({ id: "g2", weight: 20, supervisorRatingCode: "C" }),
     ]);
 
+    expect(result).toBe("S");
+  });
+
+  it("returns A for all-A goals (60 pts, ≥56 but <64)", () => {
+    const result = calculateSupervisorOverallRating([
+      buildGoal({ id: "g1", weight: 80, supervisorRatingCode: "A" }),
+      buildGoal({ id: "g2", weight: 20, supervisorRatingCode: "A" }),
+    ]);
+
+    expect(result).toBe("A");
+  });
+
+  it("returns S for S + A with 70/30 weights (74 pts)", () => {
+    const result = calculateSupervisorOverallRating([
+      buildGoal({ id: "g1", weight: 70, supervisorRatingCode: "S" }),
+      buildGoal({ id: "g2", weight: 30, supervisorRatingCode: "A" }),
+    ]);
+
+    expect(result).toBe("S");
+  });
+
+  it("returns D for single-goal D", () => {
+    const result = calculateSupervisorOverallRating([
+      buildGoal({ weight: 100, supervisorRatingCode: "D" }),
+    ]);
+
+    expect(result).toBe("D");
+  });
+
+  it("returns '−' when no goals have a rating code", () => {
+    const result = calculateSupervisorOverallRating([
+      buildGoal({ id: "g1", weight: 80, supervisorRatingCode: undefined }),
+      buildGoal({ id: "g2", weight: 20, supervisorRatingCode: undefined }),
+    ]);
+
+    expect(result).toBe("−");
+  });
+
+  it("ignores goals without a rating code but still computes from valid ones", () => {
+    const result = calculateSupervisorOverallRating([
+      buildGoal({ id: "g1", weight: 80, supervisorRatingCode: "SS" }),
+      buildGoal({ id: "g2", weight: 20, supervisorRatingCode: undefined }),
+    ]);
+
+    // (80/5) × 5 = 80 pts → S (>=70 but <86 since goal 2 contributed 0)
     expect(result).toBe("S");
   });
 });

--- a/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/PerformanceGoalsSupervisorEvaluation.tsx
+++ b/frontend/src/feature/evaluation/superviser/evaluation-feedback/display/PerformanceGoalsSupervisorEvaluation.tsx
@@ -8,7 +8,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import type { GoalResponse, SelfAssessment, SupervisorFeedback, RatingCode, SupervisorFeedbackStatus } from "@/api/types";
 import { QUANTITATIVE_RATING_CODES, QUALITATIVE_RATING_CODES, RATING_CODE_VALUES } from "@/api/types/common";
-import { scoreToFinalRating } from "@/utils/rating";
+import { calculateMboOverallRating } from "@/utils/rating";
 import { useSupervisorFeedbackAutoSave, type SaveStatus } from "../hooks/useSupervisorFeedbackAutoSave";
 
 // Display data structure for supervisor evaluation
@@ -74,27 +74,9 @@ export function transformPerformanceGoalsForSupervisor(
 }
 
 export function calculateSupervisorOverallRating(goals: PerformanceGoalSupervisorData[]): string {
-  let totalWeight = 0;
-  let weightedSum = 0;
-
-  for (const goal of goals) {
-    const weight = goal.weight || 0;
-    if (weight <= 0) continue;
-
-    let score: number | undefined;
-    if (goal.supervisorRatingCode) {
-      score = RATING_CODE_VALUES[goal.supervisorRatingCode];
-    } else if (typeof goal.supervisorRating === "number" && Number.isFinite(goal.supervisorRating)) {
-      score = goal.supervisorRating;
-    }
-
-    if (typeof score !== "number") continue;
-    weightedSum += score * weight;
-    totalWeight += weight;
-  }
-
-  if (totalWeight === 0) return "−";
-  return scoreToFinalRating(weightedSum / totalWeight);
+  return calculateMboOverallRating(
+    goals.map(goal => ({ rating: goal.supervisorRatingCode, weight: goal.weight }))
+  );
 }
 
 /**

--- a/frontend/src/utils/rating.ts
+++ b/frontend/src/utils/rating.ts
@@ -140,6 +140,66 @@ export function calculateCoreValueRatingAverage(
 }
 
 /**
+ * MBO score table for performance goals (業績目標). Spec section 4-2.
+ * Different from RATING_CODE_VALUES: MBO uses a 5-point scale (SS=5, D=0),
+ * while the general 8-level scale uses 0-7 (SS=7, D=0).
+ */
+const MBO_SCORE: Partial<Record<RatingCode, number>> = {
+  SS: 5,
+  S: 4,
+  A: 3,
+  B: 2,
+  C: 1,
+  D: 0,
+};
+
+/**
+ * MBO final rating thresholds on 0-100 scale. Spec section 4-3.
+ * Ordered high-to-low for sequential lookup.
+ */
+const MBO_THRESHOLDS: ReadonlyArray<readonly [FinalRatingCode, number]> = [
+  ['SS', 86],
+  ['S', 70],
+  ['A+', 64],
+  ['A', 56],
+  ['A-', 50],
+  ['B', 34],
+  ['C', 20],
+  ['D', 0],
+];
+
+/**
+ * Calculates the MBO overall rating for performance goals (業績目標).
+ * Mirrors the backend SQL formula (spec sections 4-2, 4-3, 4-4):
+ *   total = Σ (weight/5) × MBO_SCORE[rating]
+ *   threshold: SS≥86, S≥70, A+≥64, A≥56, A-≥50, B≥34, C≥20, D<20
+ *
+ * @param items - Array of { rating, weight } objects
+ * @returns The FinalRatingCode string, or '−' if no valid ratings
+ */
+export function calculateMboOverallRating(
+  items: Array<{ rating?: RatingCode | null; weight: number }>
+): string {
+  let total = 0;
+  let hasValid = false;
+
+  for (const item of items) {
+    if (!item.rating || item.weight <= 0) continue;
+    const score = MBO_SCORE[item.rating];
+    if (score === undefined) continue;
+    total += (item.weight / 5) * score;
+    hasValid = true;
+  }
+
+  if (!hasValid) return '−';
+
+  for (const [rank, min] of MBO_THRESHOLDS) {
+    if (total >= min) return rank;
+  }
+  return 'D';
+}
+
+/**
  * Returns Tailwind CSS classes for a rating badge based on the rating code.
  */
 export function getRatingColor(rating: string | null): string {


### PR DESCRIPTION
## Summary

- Corrige o cálculo do `総合評価` do 業績目標 exibido nos cards das telas de input (supervisor feedback + employee self-evaluation) para usar a fórmula MBO do spec (seções 4-2/4-3/4-4), em paridade com o SQL do backend
- Tela admin `admin-eval-list` já estava correta (consome `performanceFinalRank` pronto do backend) e não foi tocada
- Bug reportado: 定量 SS @ 80% + 定性 A @ 20% exibia **"S"** quando deveria ser **"SS"** (92 pts ≥ 86)

## Causa

Frontend computava via média ponderada na escala 0-7 (SS=7, threshold 6.5):
```
avg = (7 × 80 + 4 × 20) / 100 = 6.4  → "S" (6.4 < 6.5)
```

Spec e backend usam escala 0-100 com `(weight/5) × score`, SS=5:
```
total = (80/5) × 5 + (20/5) × 3 = 92  → "SS" (92 ≥ 86)
```

## Mudanças

- **`utils/rating.ts`** — novo helper `calculateMboOverallRating` com `MBO_SCORE` (5-point, spec 4-2) e `MBO_THRESHOLDS` (0-100, spec 4-3). Mantém os helpers existentes 0-7 para competency/core-value
- **`PerformanceGoalsSelfAssessment.tsx`** — `calculatePerformanceOverallRating` agora chama o helper MBO
- **`PerformanceGoalsSupervisorEvaluation.tsx`** — `calculateSupervisorOverallRating` agora chama o helper MBO (removidos fallback numeric não usado e import `scoreToFinalRating`)
- **`PerformanceGoalsEvaluate.tsx`** — idem no fluxo de auto-avaliação do funcionário
- **Testes** — atualizado `PerformanceGoalsSupervisorEvaluation.test.ts` com 9 casos (regression do 西松, todos SS, todos D, SS+C, all-A, S+A 70/30, '−' sem ratings, goal sem rating ignorado)

## Paridade backend

Mesma fórmula de [`comprehensive_evaluation_repo.py`](backend/app/database/repositories/comprehensive_evaluation_repo.py) (`SUM((weight/5.0) * CASE code WHEN 'SS' THEN 5.0 ...)`) e mesmos `MBO_THRESHOLDS` de [`comprehensive_evaluation_service.py`](backend/app/services/comprehensive_evaluation_service.py). Preview ao vivo do frontend agora ≡ resultado final persistido.

## Escopo intencionalmente não tocado

- Backend — já correto
- `admin/comprehensive-evaluation/logic.ts` — já correto (consome `performanceFinalRank`)
- Competency e core-value — usam `calculateAverageRatingCode` (simple avg em 0-7), consistente com spec 5-4 / 6-4

## Test plan

- [x] `npm test` — 112/112 passam (9 novos no `PerformanceGoalsSupervisorEvaluation.test.ts`)
- [x] `npx tsc --noEmit` — 0 erros novos (6 pré-existentes em outros arquivos, idênticos antes e depois)
- [ ] Validação manual em staging (develop): reproduzir o caso do user 1703 no 上長評価画面 e confirmar **SS**
- [ ] Validar casos de borda: todos SS → SS, todos D → D, SS+C 80/20 → S

🤖 Generated with [Claude Code](https://claude.com/claude-code)